### PR TITLE
remove result once ready

### DIFF
--- a/health_check_celery3/plugin_health_check.py
+++ b/health_check_celery3/plugin_health_check.py
@@ -13,7 +13,8 @@ class CeleryHealthCheck(BaseHealthCheckBackend):
             now = datetime.now()
             while (now + timedelta(seconds=3)) > datetime.now():
                 print "            checking...."
-                if result.result == 8:
+                if result.ready():
+                    result.forget()
                     return True
                 sleep(0.5)
         except IOError:

--- a/health_check_celery3/tasks.py
+++ b/health_check_celery3/tasks.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+
 from celery import shared_task
 
 


### PR DESCRIPTION
@stefanfoulis I remember we talked about not relying on result backend, but celery actually requires it and .read() will not work without it, so instead of removing it I simply remove the result to cleanup.
