### PR TITLE
Keep __context__ for custom exeptions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ class DjangoDatabaseBackend(BaseHealthCheckBackend):
             obj.save()
             obj.delete()
             return True
-        except IntegrityError:
-            raise ServiceReturnedUnexpectedResult("Integrity Error")
-        except DatabaseError:
-            raise ServiceUnavailable("Database error")
+        except IntegrityError as e:
+            raise ServiceReturnedUnexpectedResult("Integrity Error") from e
+        except DatabaseError as e:
+            raise ServiceUnavailable("Database error") from e
 
 
 ```

--- a/health_check_cache/plugin_health_check.py
+++ b/health_check_cache/plugin_health_check.py
@@ -12,11 +12,11 @@ class CacheBackend(BaseHealthCheckBackend):
                 return True
             else:
                 raise ServiceUnavailable("Cache key does not match")
-        except CacheKeyWarning:
-            raise ServiceReturnedUnexpectedResult("Cache key warning")
-        except ValueError:
-            raise ServiceReturnedUnexpectedResult("ValueError")
-        except Exception:
-            raise ServiceUnavailable("Unknown exception")
+        except CacheKeyWarning as e:
+            raise ServiceReturnedUnexpectedResult("Cache key warning") from e
+        except ValueError as e:
+            raise ServiceReturnedUnexpectedResult("ValueError") from e
+        except Exception as e:
+            raise ServiceUnavailable("Unknown exception") from e
 
 plugin_dir.register(CacheBackend)

--- a/health_check_db/plugin_health_check.py
+++ b/health_check_db/plugin_health_check.py
@@ -12,9 +12,9 @@ class DjangoDatabaseBackend(BaseHealthCheckBackend):
             obj.save()
             obj.delete()
             return True
-        except IntegrityError:
-            raise ServiceReturnedUnexpectedResult("Integrity Error")
-        except DatabaseError:
-            raise ServiceUnavailable("Database error")
+        except IntegrityError as e:
+            raise ServiceReturnedUnexpectedResult("Integrity Error") from e
+        except DatabaseError as e:
+            raise ServiceUnavailable("Database error") from e
 
 plugin_dir.register(DjangoDatabaseBackend)

--- a/health_check_storage/base.py
+++ b/health_check_storage/base.py
@@ -51,5 +51,5 @@ class StorageHealthCheck(BaseHealthCheckBackend):
             if storage.exists(file_name):
                 return ServiceUnavailable("File was not deleted")
             return True
-        except Exception:
-            raise ServiceUnavailable("Unknown exception")
+        except Exception as e:
+            raise ServiceUnavailable("Unknown exception") from e


### PR DESCRIPTION
This is py3 only.

Since python there is an option to keep the `__context__`
when reraising exceptions. This may only change the exception
type but not the context when and where it was raised.
