### PR TITLE
Update __init__.py

### DIFF
--- a/health_check/__init__.py
+++ b/health_check/__init__.py
@@ -18,7 +18,7 @@ def autodiscover():
 
     import copy
     from django.conf import settings
-    from django.utils.importlib import import_module
+    from importlib import import_module
     from django.utils.module_loading import module_has_submodule
     from health_check.plugins import plugin_dir
 


### PR DESCRIPTION
Modifications to switch to python based import lib. Django based importlib was removed in django 1.9
