### PR TITLE
Catch Celery forget() not implemented error

### DIFF
--- a/health_check_celery3/plugin_health_check.py
+++ b/health_check_celery3/plugin_health_check.py
@@ -27,7 +27,10 @@ class CeleryHealthCheck(BaseHealthCheckBackend):
             while (now + timedelta(seconds=3)) > datetime.now():
                 print("            checking....")
                 if result.ready():
-                    result.forget()
+                    try:
+                        result.forget()
+                    except NotImplementedError:
+                        pass
                     return True
                 sleep(0.5)
         except IOError:


### PR DESCRIPTION
When using AMQP as the backend, `result.forget()` raises an error, which causes the test to fail even though Celery is working perfectly fine. In such cases this error should be caught and ignored.
