### PR TITLE
Windows fixes

### DIFF
--- a/health_check_storage/base.py
+++ b/health_check_storage/base.py
@@ -38,7 +38,7 @@ class StorageHealthCheck(BaseHealthCheckBackend):
 
     def get_file_name(self):
         return 'health_check_storage_test/test-{}-{}.txt'.format(
-            datetime.datetime.now(),
+            datetime.datetime.now().strftime('%Y%m%dT%H%M%SZ'),
             random.randint(10000, 99999)
         )
 

--- a/health_check_storage/base.py
+++ b/health_check_storage/base.py
@@ -57,11 +57,11 @@ class StorageHealthCheck(BaseHealthCheckBackend):
                 file_name, ContentFile(content=file_content)
             )
             # read the file and compare
-            f = storage.open(file_name)
             if not storage.exists(file_name):
                 raise ServiceUnavailable('File does not exist')
-            if not f.read() == file_content:
-                return ServiceUnavailable('File content doesn\'t match')
+            with storage.open(file_name) as f:
+                if not f.read() == file_content:
+                    return ServiceUnavailable('File content doesn\'t match')
             # delete the file and make sure it is gone
             storage.delete(file_name)
             if storage.exists(file_name):


### PR DESCRIPTION
Windows fails on current master branch on Storage health checking.

**Problem 1** is that file names were generated with `datetime.datetime.__str__`, which formats the file names with ISO8601 format which includes colons, `:`, by default, [which are reserved characters in Windows](https://msdn.microsoft.com/en-us/library/windows/desktop/aa365247%28v=vs.85%29.aspx). I have converted the file naming to generate names in alternative [ISO8601 format](https://en.wikipedia.org/wiki/ISO_8601), which should still be equally machine-readable.

**Problem 2** is that file handles that were created for tempfile content validation were not being closed implicitly or explicitly, which is fixed by the included `with open as` method, which guarantees file handles will be closed even when exceptions are raised.
