### PR TITLE
AppConfigs

### DIFF
--- a/health_check/__init__.py
+++ b/health_check/__init__.py
@@ -20,6 +20,7 @@ def autodiscover():
 
     autodiscover_modules('plugin_health_check', register_to=plugin_dir)
 
+
 def get_version(short=False):
     assert __version_info__['releaselevel'] in ('alpha', 'beta', 'final')
     vers = ["%(major)i.%(minor)i" % __version_info__, ]

--- a/health_check/__init__.py
+++ b/health_check/__init__.py
@@ -1,4 +1,5 @@
 # This file is heavily inspired from the django admin autodiscover
+from django.utils.module_loading import autodiscover_modules
 
 __version_info__ = {
     'major': 1,
@@ -15,31 +16,9 @@ def autodiscover():
 
     This forces an import on them to register any admin bits they may want.
     """
-    import copy
-    from django.conf import settings
-    from importlib import import_module
-    from django.utils.module_loading import module_has_submodule
     from health_check.plugins import plugin_dir
 
-    for app in settings.INSTALLED_APPS:
-        mod = import_module(app)
-        # Attempt to import the app's admin module.
-        try:
-            before_import_registry = copy.copy(plugin_dir._registry)
-            import_module('%s.plugin_health_check' % app)
-        except:
-            # Reset the model registry to the state before the last import as
-            # this import will have to reoccur on the next request and this
-            # could raise NotRegistered and AlreadyRegistered exceptions
-            # (see #8245).
-            plugin_dir._registry = before_import_registry
-
-            # Decide whether to bubble up this error. If the app just
-            # doesn't have an admin module, we can ignore the error
-            # attempting to import it, otherwise we want it to bubble up.
-            if module_has_submodule(mod, 'plugin_health_check'):
-                raise
-
+    autodiscover_modules('plugin_health_check', register_to=plugin_dir)
 
 def get_version(short=False):
     assert __version_info__['releaselevel'] in ('alpha', 'beta', 'final')

--- a/health_check/__init__.py
+++ b/health_check/__init__.py
@@ -8,6 +8,8 @@ __version_info__ = {
     'serial': 0
 }
 
+default_app_config = 'health_check.apps.HealthCheckConfig'
+
 
 def autodiscover():
     """

--- a/health_check/__init__.py
+++ b/health_check/__init__.py
@@ -1,5 +1,4 @@
-# This file is heavily inspired from the django admin autodiscover
-from django.utils.module_loading import autodiscover_modules
+# Used by setup.py, so minimize top-level imports.
 
 __version_info__ = {
     'major': 1,
@@ -16,6 +15,7 @@ def autodiscover():
 
     This forces an import on them to register any admin bits they may want.
     """
+    from django.utils.module_loading import autodiscover_modules
     from health_check.plugins import plugin_dir
 
     autodiscover_modules('plugin_health_check', register_to=plugin_dir)

--- a/health_check/apps.py
+++ b/health_check/apps.py
@@ -1,0 +1,8 @@
+from django.apps import AppConfig
+
+
+class HealthCheckConfig(AppConfig):
+    name = 'health_check'
+
+    def ready(self):
+        self.module.autodiscover()


### PR DESCRIPTION
Closes #53.

Adds support for the use of explicit `AppConfig` references in `INSTALLED_APPS`.
