### PR TITLE
Add released Django 1.10 to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ env:
   matrix:
   - DJANGO="Django<1.9,>=1.8"
   - DJANGO="Django<1.10,>=1.9"
+  - DJANGO="Django<1.11,>=1.10"
   - DJANGO="-e git+https://github.com/django/django.git@master#egg=Django"
 matrix:
   fast_finish: true


### PR DESCRIPTION
Django 1.10 is released, so add to travis.
