### PR TITLE
Add logger methods to BaseHealthCheckBackend

### DIFF
--- a/health_check/backends/base.py
+++ b/health_check/backends/base.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+from logging import getLogger
+
 from django.utils.translation import ugettext_lazy as _
 
 
@@ -44,6 +46,23 @@ class BaseHealthCheckBackend(object):
                 setattr(self, "_status", e.code)
 
         return self._status
+
+    def get_logger(self, logger):
+        if logger:
+            return logger
+        if hasattr(self, "logger"):
+            return self.logger
+        return getLogger(self.__module__)
+
+    def error(self, exception_class, message, logger):
+        self.get_logger(logger).exception(message)
+        raise exception_class(message)
+
+    def unexpected(self, message, logger=None):
+        self.error(ServiceReturnedUnexpectedResult, message, logger)
+
+    def unavailable(self, message, logger=None):
+        self.error(ServiceUnavailable, message, logger)
 
     def pretty_status(self):
         return "%s" % (HEALTH_CHECK_STATUS_TYPE_TRANSLATOR[self.status])

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -1,8 +1,24 @@
 # -*- coding: utf-8 -*-
-from health_check.backends.base import BaseHealthCheckBackend
+import pytest
+
+from health_check.backends.base import (
+    BaseHealthCheckBackend, ServiceReturnedUnexpectedResult, ServiceUnavailable
+)
 
 
 class TestBaseHealthCheckBackend(object):
 
     def test_status(self):
         assert BaseHealthCheckBackend().status is None
+
+    def test_error(self):
+        with pytest.raises(Exception):
+            BaseHealthCheckBackend().error(Exception, '.error() raises correctly', None)
+
+    def test_unavailable(self):
+        with pytest.raises(ServiceUnavailable):
+            BaseHealthCheckBackend().unavailable('.unavailable() raises correctly')
+
+    def test_unexpected(self):
+        with pytest.raises(ServiceReturnedUnexpectedResult):
+            BaseHealthCheckBackend().unexpected('.unexpected() raises correctly')


### PR DESCRIPTION
This patchset introduces logging facilities to base health check backend, which allows subclasses to use uniform logging APIs across the project.

This is base work addressing #14 along with current logging conventions and tries to improve the project code quality.