### PR TITLE
Improve Python 2.7 compatibility by adding explicit coding to project files

### DIFF
--- a/health_check/__init__.py
+++ b/health_check/__init__.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Used by setup.py, so minimize top-level imports.
 
 __version_info__ = {

--- a/health_check/backends/base.py
+++ b/health_check/backends/base.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
 from django.utils.translation import ugettext_lazy as _

--- a/health_check/plugins.py
+++ b/health_check/plugins.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # This is heavily inspired by the django admin sites.py
 
 from health_check.backends.base import BaseHealthCheckBackend

--- a/health_check/urls.py
+++ b/health_check/urls.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from django.conf.urls import url
 
 import health_check

--- a/health_check/views.py
+++ b/health_check/views.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from django.http import HttpResponse, HttpResponseServerError
 from django.template import loader
 

--- a/health_check_cache/plugin_health_check.py
+++ b/health_check_cache/plugin_health_check.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from django.core.cache import cache
 from django.core.cache.backends.base import CacheKeyWarning
 

--- a/health_check_celery/plugin_health_check.py
+++ b/health_check_celery/plugin_health_check.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from datetime import datetime, timedelta
 from time import sleep
 

--- a/health_check_celery/tasks.py
+++ b/health_check_celery/tasks.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from celery.task import task
 
 

--- a/health_check_celery3/plugin_health_check.py
+++ b/health_check_celery3/plugin_health_check.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import logging
 from datetime import datetime, timedelta
 from time import sleep

--- a/health_check_celery3/tasks.py
+++ b/health_check_celery3/tasks.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
 from celery import shared_task

--- a/health_check_db/models.py
+++ b/health_check_db/models.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from django.db import models
 
 

--- a/health_check_db/plugin_health_check.py
+++ b/health_check_db/plugin_health_check.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import logging
 
 from django.db import DatabaseError, IntegrityError

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import os
 
 from setuptools import setup

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from health_check.backends.base import BaseHealthCheckBackend
 
 

--- a/tests/testapp/settings.py
+++ b/tests/testapp/settings.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import os.path
 import uuid
 

--- a/tests/testapp/urls.py
+++ b/tests/testapp/urls.py
@@ -1,4 +1,4 @@
-# -*- conding:utf-8 -*-
+# -*- coding: utf-8 -*-
 from __future__ import absolute_import, unicode_literals
 
 urlpatterns = []


### PR DESCRIPTION
This patchset adds unicode coding tags for better Python 2 compatibility.