### PR TITLE
Add S3BotoStorage health checker

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -6,3 +6,4 @@ The following people have contributed to django-health-check:
 - Stefan Foulis
 - Christian Pedersen
 - Johannes Hoppe
+- Aleksi Häkli

--- a/health_check_storage_s3/plugin_health_check.py
+++ b/health_check_storage_s3/plugin_health_check.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+import logging
+
+from health_check.plugins import plugin_dir
+from health_check_storage.base import StorageHealthCheck
+
+
+class S3BotoStorageHealthCheck(StorageHealthCheck):
+    """
+    Tests the status of a `S3BotoStorage` file storage backend.
+
+    S3BotoStorage is included in the `django-storages` package
+    and recommended by for example Amazon and Heroku for Django
+    static and media file storage on cloud platforms.
+
+    ``django-storages`` can be found at https://git.io/v1lGx
+    ``S3BotoStorage`` can be found at https://git.io/v1lGF
+    """
+
+    logger = logging.getLogger(__name__)
+    storage = 'storages.backends.s3boto.S3BotoStorage'
+
+    def check_delete(self, file_name):
+        storage = self.get_storage()
+        storage.delete(file_name)
+
+plugin_dir.register(S3BotoStorageHealthCheck)

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
         'health_check_cache',
         'health_check.backends',
         'health_check_storage',
+        'health_check_storage_s3',
     ],
     long_description=read('README.md'),
     classifiers=[


### PR DESCRIPTION
Add a backend offering S3BotoStorage health checking support. This patchset depends on #64 and is offered as unstable version at first, hence not documented in README. API does not conflict with the existing APIs nor break backwards compatibility. Fixes #17.