### PR TITLE
Fixes expiration issue with timezone

### DIFF
--- a/health_check/contrib/celery/backends.py
+++ b/health_check/contrib/celery/backends.py
@@ -1,7 +1,6 @@
 from datetime import timedelta
 
 from django.conf import settings
-from django.utils import timezone
 
 from health_check.backends import BaseHealthCheckBackend
 from health_check.exceptions import (
@@ -18,7 +17,7 @@ class CeleryHealthCheck(BaseHealthCheckBackend):
         try:
             result = add.apply_async(
                 args=[4, 4],
-                expires=timezone.now() + timedelta(seconds=timeout)
+                expires=timeout
             )
             result.get(timeout=timeout)
             if result.result != 8:

--- a/health_check/contrib/celery/backends.py
+++ b/health_check/contrib/celery/backends.py
@@ -1,5 +1,3 @@
-from datetime import timedelta
-
 from django.conf import settings
 
 from health_check.backends import BaseHealthCheckBackend


### PR DESCRIPTION
Replace expiration expressed in datetime object with integer seconds to avoid expiration issue (reported as Discarding revoked task).