### PR TITLE
README: Migrations must be run if using DB check

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,6 +51,12 @@ Add the ``health_check`` applications to your ``INSTALLED_APPS``:
         'health_check.contrib.s3boto_storage',      # requires boto and S3BotoStorage backend
     ]
 
+If using the DB check, run migrations:
+
+.. code::
+
+    django-admin migrate
+
 Setting up monitoring
 ---------------------
 


### PR DESCRIPTION
I was confused when the DB check reported a "Database Error" even though everything seemed to be functioning normally. Upon further investigation, I discovered that there is a migration that must be run for the DB check to function, so I took the liberty of documenting that in the README.