### PR TITLE
Add checks for disk and memory utilization

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,14 +4,15 @@ django-health-check
 
 |version| |ci| |coverage| |health| |license|
 
-This project checks the health for a number of backends and sees if they are able
-to connect and do a simple action.
+This project checks for various conditions and provides reports when anomalous
+behavior is detected.
 
-The following health check backends are bundled into this project:
+The following health checks are bundled with this project:
 
-- Cache
-- Database
-- Storage
+- cache
+- database
+- storage
+- disk and memory utilization (via ``psutil``)
 - AWS S3 storage
 - Celery task queue
 
@@ -19,10 +20,22 @@ Writing your own custom health checks is also very quick and easy.
 
 We also like contributions, so don't be afraid to make a pull request.
 
+Use Cases
+---------
+
+The primary intended use case is to monitor conditions via HTTP(S), with
+responses available in HTML and JSON formats. When you get back a response that
+includes one or more problems, you can then decide the appropriate course of
+action, which could include generating notifications and/or automating the
+replacement of a failing node with a new one. If you are monitoring health in a
+high-availability environment with a load balancer that returns responses from
+multiple nodes, please note that certain checks (e.g., disk and memory usage)
+will return responses specific to the node selected by the load balancer.
+
 Supported Versions
 ------------------
 
-We officially only support the latest Version of Python as well as the
+We officially only support the latest version of Python as well as the
 latest version of Django and the latest Django LTS version.
 
 .. note:: The latest version to support Python 2 is 2.4.0
@@ -36,7 +49,7 @@ First install the ``django-health-check`` package:
 
     pip install django-health-check
 
-Add the health checker to an URL you want to use:
+Add the health checker to a URL you want to use:
 
 .. code:: python
 
@@ -56,8 +69,20 @@ Add the ``health_check`` applications to your ``INSTALLED_APPS``:
         'health_check.cache',
         'health_check.storage',
         'health_check.contrib.celery',              # requires celery
+        'health_check.contrib.psutil',              # disk and memory utilization; requires psutil
         'health_check.contrib.s3boto_storage',      # requires boto and S3BotoStorage backend
     ]
+
+(Optional) If using the ``psutil`` app, you can configure disk and memory
+threshold settings; otherwise below defaults are assumed. If you want to disable
+one of these checks, set its value to ``None``.
+
+.. code:: python
+
+    HEALTH_CHECK = {
+        'DISK_USAGE_MAX': 90,  # percent
+        'MEMORY_MIN' = 100,    # in MB
+    }
 
 If using the DB check, run migrations:
 

--- a/docs/contrib.rst
+++ b/docs/contrib.rst
@@ -1,0 +1,37 @@
+contrib
+=======
+
+``psutil``
+----------
+
+Full disks and out-of-memory conditions are common causes of service outages.
+These situations can be averted by checking disk and memory utilization via the
+``psutil`` package:
+
+.. code::
+
+    pip install psutil
+
+Once that dependency has been installed, make sure that the corresponding Django
+app has been added to ``INSTALLED_APPS``:
+
+.. code:: python
+
+    INSTALLED_APPS = [
+        # ...
+        'health_check',                             # required
+        'health_check.contrib.psutil',              # disk and memory utilization; requires psutil
+        # ...
+    ]
+
+The following default settings will be used to check for disk and memory
+utilization. If you would prefer different thresholds, you can add the dictionary
+below to your Django settings file and adjust the values accordingly. If you want
+to disable any of these checks, set its value to ``None``.
+
+.. code:: python
+
+    HEALTH_CHECK = {
+        'DISK_USAGE_MAX': 90,  # percent
+        'MEMORY_MIN' = 100,    # in MB
+    }

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,12 +1,15 @@
 django-health-check
 -------------------
 
-This project checks the health for a number of backends and sees if they are able
-to connect and do a simple action.
+This project checks for various conditions and provides reports when anomalous
+behavior is detected. Many of these checks involve connecting to back-end
+services and ensuring basic operations are successful.
 
 .. toctree::
    :maxdepth: 2
    :caption: Contents:
 
    readme
+   contrib
+   settings
    changelog

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -1,0 +1,32 @@
+Settings
+========
+
+Settings can be configured via the ``HEALTH_CHECK`` dictionary.
+
+``psutil``
+----------
+
+The following default settings will be used to check for disk and memory
+utilization. If you would prefer different thresholds, you can add the dictionary
+below to your Django settings file and adjust the values accordingly. If you want
+to disable any of these checks, set its value to ``None``.
+
+.. code:: python
+
+    HEALTH_CHECK = {
+        'DISK_USAGE_MAX': 90,  # percent
+        'MEMORY_MIN' = 100,    # in MB
+    }
+
+With the above default settings, warnings will be reported when disk utilization
+exceeds 90% or available memory drops below 100 MB.
+
+.. data:: DISK_USAGE_MAX
+
+   Specify the desired disk utilization threshold, in percent. When disk usage
+   exceeds the specified value, a warning will be reported.
+
+.. data:: MEMORY_MIN
+
+   Specify the desired memory utilization threshold, in megabytes. When available
+   memory falls below the specified value, a warning will be reported.

--- a/health_check/contrib/psutil/__init__.py
+++ b/health_check/contrib/psutil/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'health_check.contrib.psutil.apps.HealthCheckConfig'

--- a/health_check/contrib/psutil/apps.py
+++ b/health_check/contrib/psutil/apps.py
@@ -1,0 +1,24 @@
+from django.apps import AppConfig
+from django.conf import settings
+
+from health_check.plugins import plugin_dir
+
+
+class HealthCheckConfig(AppConfig):
+    name = 'health_check.contrib.psutil'
+
+    def ready(self):
+        from .backends import DiskUsage, MemoryUsage
+        # Ensure checks haven't been explicitly disabled before registering
+        if (hasattr(settings, 'HEALTH_CHECK') and
+                ('DISK_USAGE_MAX' in settings.HEALTH_CHECK) and
+                (settings.HEALTH_CHECK['DISK_USAGE_MAX'] is None)):
+            pass
+        else:
+            plugin_dir.register(DiskUsage)
+        if (hasattr(settings, 'HEALTH_CHECK') and
+                ('DISK_USAGE_MAX' in settings.HEALTH_CHECK) and
+                (settings.HEALTH_CHECK['MEMORY_MIN'] is None)):
+            pass
+        else:
+            plugin_dir.register(MemoryUsage)

--- a/health_check/contrib/psutil/backends.py
+++ b/health_check/contrib/psutil/backends.py
@@ -1,0 +1,46 @@
+import locale
+import socket
+
+from django.conf import settings
+
+import psutil
+from health_check.backends import BaseHealthCheckBackend
+from health_check.exceptions import (
+    ServiceReturnedUnexpectedResult, ServiceWarning
+)
+
+host = socket.gethostname()
+
+if hasattr(settings, 'HEALTH_CHECK'):
+    DISK_USAGE_MAX = settings.HEALTH_CHECK.get('DISK_USAGE_MAX', 90)  # in %
+    MEMORY_MIN = settings.HEALTH_CHECK.get('MEMORY_MIN', 100)  # in MB
+else:
+    DISK_USAGE_MAX = 90  # in %
+    MEMORY_MIN = 100  # in MB
+
+
+class DiskUsage(BaseHealthCheckBackend):
+    def check_status(self):
+        try:
+            du = psutil.disk_usage('/')
+            if DISK_USAGE_MAX and du.percent >= DISK_USAGE_MAX:
+                raise ServiceWarning(
+                    f"{host} {du.percent}% disk usage exceeds {DISK_USAGE_MAX}%"
+                )
+        except ValueError as e:
+            self.add_error(ServiceReturnedUnexpectedResult("ValueError"), e)
+
+
+class MemoryUsage(BaseHealthCheckBackend):
+    def check_status(self):
+        try:
+            memory = psutil.virtual_memory()
+            if MEMORY_MIN and memory.available < (MEMORY_MIN * 1024 * 1024):
+                locale.setlocale(locale.LC_ALL, '')
+                avail = '{:n}'.format(int(memory.available / 1024 / 1024))
+                threshold = '{:n}'.format(MEMORY_MIN)
+                raise ServiceWarning(
+                    f"{host} {avail} MB available RAM below {threshold} MB"
+                )
+        except ValueError as e:
+            self.add_error(ServiceReturnedUnexpectedResult("ValueError"), e)

--- a/health_check/exceptions.py
+++ b/health_check/exceptions.py
@@ -11,6 +11,10 @@ class HealthCheckException(Exception):
         return "%s: %s" % (self.message_type, self.message)
 
 
+class ServiceWarning(HealthCheckException):
+    message_type = _("warning")
+
+
 class ServiceUnavailable(HealthCheckException):
     message_type = _("unavailable")
 


### PR DESCRIPTION
Full disks and out-of-memory conditions are among the primary causes of
service outages, and they are easy to check for.