### PR TITLE
Fix #178 -- Close connections when exeting threads

### DIFF
--- a/health_check/views.py
+++ b/health_check/views.py
@@ -22,7 +22,11 @@ class MainView(TemplateView):
 
         def _run(plugin):
             plugin.run_check()
-            return plugin.errors
+            try:
+                return plugin.errors
+            finally:
+                from django.db import connection
+                connection.close_if_unusable_or_obsolete()
 
         with ThreadPoolExecutor(max_workers=len(plugins) or 1) as executor:
             for ers in executor.map(_run, plugins):


### PR DESCRIPTION
Django uses separate connections for each thread be default.
Open connections are only closed by default when the
`request_finished` signal is called, which does not happen in our
case.