### PR TITLE
Replace f-strings with standard strings, for Python 3.5 compatibility

### DIFF
--- a/health_check/contrib/psutil/backends.py
+++ b/health_check/contrib/psutil/backends.py
@@ -25,7 +25,8 @@ class DiskUsage(BaseHealthCheckBackend):
             du = psutil.disk_usage('/')
             if DISK_USAGE_MAX and du.percent >= DISK_USAGE_MAX:
                 raise ServiceWarning(
-                    f"{host} {du.percent}% disk usage exceeds {DISK_USAGE_MAX}%"
+                    "{} {}% disk usage exceeds {}%".format(
+                        host, du.percent, DISK_USAGE_MAX)
                 )
         except ValueError as e:
             self.add_error(ServiceReturnedUnexpectedResult("ValueError"), e)
@@ -40,7 +41,8 @@ class MemoryUsage(BaseHealthCheckBackend):
                 avail = '{:n}'.format(int(memory.available / 1024 / 1024))
                 threshold = '{:n}'.format(MEMORY_MIN)
                 raise ServiceWarning(
-                    f"{host} {avail} MB available RAM below {threshold} MB"
+                    "{} {} MB available RAM below {} MB".format(
+                        host, avail, threshold)
                 )
         except ValueError as e:
             self.add_error(ServiceReturnedUnexpectedResult("ValueError"), e)

--- a/health_check/contrib/psutil/backends.py
+++ b/health_check/contrib/psutil/backends.py
@@ -25,8 +25,8 @@ class DiskUsage(BaseHealthCheckBackend):
             du = psutil.disk_usage('/')
             if DISK_USAGE_MAX and du.percent >= DISK_USAGE_MAX:
                 raise ServiceWarning(
-                    "{host} {percent}% disk usage exceeds {}%".format(
-                        host=host, percent=du.percent, DISK_USAGE_MAX)
+                    "{host} {percent}% disk usage exceeds {disk_usage}%".format(
+                        host=host, percent=du.percent, disk_usage=DISK_USAGE_MAX)
                 )
         except ValueError as e:
             self.add_error(ServiceReturnedUnexpectedResult("ValueError"), e)

--- a/health_check/contrib/psutil/backends.py
+++ b/health_check/contrib/psutil/backends.py
@@ -25,8 +25,8 @@ class DiskUsage(BaseHealthCheckBackend):
             du = psutil.disk_usage('/')
             if DISK_USAGE_MAX and du.percent >= DISK_USAGE_MAX:
                 raise ServiceWarning(
-                    "{} {}% disk usage exceeds {}%".format(
-                        host, du.percent, DISK_USAGE_MAX)
+                    "{host} {percent}% disk usage exceeds {}%".format(
+                        host=host, percent=du.percent, DISK_USAGE_MAX)
                 )
         except ValueError as e:
             self.add_error(ServiceReturnedUnexpectedResult("ValueError"), e)
@@ -41,8 +41,8 @@ class MemoryUsage(BaseHealthCheckBackend):
                 avail = '{:n}'.format(int(memory.available / 1024 / 1024))
                 threshold = '{:n}'.format(MEMORY_MIN)
                 raise ServiceWarning(
-                    "{} {} MB available RAM below {} MB".format(
-                        host, avail, threshold)
+                    "{host} {avail} MB available RAM below {threshold} MB".format(
+                        host=host, avail=avail, threshold=threshold)
                 )
         except ValueError as e:
             self.add_error(ServiceReturnedUnexpectedResult("ValueError"), e)


### PR DESCRIPTION
Hi,

there are two f-strings in `health_check.contrib.psutil.backends`, in example:

    raise ServiceWarning(
        f"{host} {du.percent}% disk usage exceeds {DISK_USAGE_MAX}%"
    )

The f-strings are supported in Python 3.6, but not in Python 3.5.
(No other modules are affected, only the `psutil`)

I know that this package is not supposed to support 3.5, as defined in the docs:

> We officially only support the latest version of Python as well as the latest version of Django and the latest Django LTS version.

However, I think it's reasonable to "unofficially" support 3.5:
- Ubuntu 16.04 LTS has Python 3.5. 3.6 is not in the repositories
- Ubuntu 16.04 will be supported until 2021, so this will affect more people
- the change is trivial (just 2 strings)
- of course, I don't expect you to 3.5 support forever :)

What do you think?

PD: Thanks for the `django-health-check` package!