### PR TITLE
`critical` flag, better JSON response

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -155,6 +155,9 @@ The backend will return a JSON response:
         "S3BotoStorageHealthCheck": "working"
     }
 
+Optionally, the ``JSON_VERBOSE`` can be set to ``True`` in ``HEALTH_CHECK`` settings to output additional details about
+each plugin (for instance, response time).
+
 Writing a custom health check
 -----------------------------
 
@@ -165,6 +168,15 @@ Writing a health check is quick and easy:
     from health_check.backends import BaseHealthCheckBackend
 
     class MyHealthCheckBackend(BaseHealthCheckBackend):
+        def __init__(self):
+            super().__init__()
+
+            # This flag indicates whether or not this plugin
+            # failing represents a critical health failure.
+            # If False,  a failure on this plugin will still
+            # allow a status_code of 200 to be returned
+            self.critical = False
+
         def check_status(self):
             # The test code goes here.
             # You can use `self.add_error` or
@@ -210,16 +222,16 @@ and customizing the ``template_name``, ``get``, ``render_to_response`` and ``ren
             plugins = []
             # ...
             if 'application/json' in request.META.get('HTTP_ACCEPT', ''):
-                return self.render_to_response_json(plugins, status)
-            return self.render_to_response(plugins, status)
+                return self.render_to_response_json(plugins, status_code)
+            return self.render_to_response(plugins, status_code)
 
-        def render_to_response(self, plugins, status):       # customize HTML output
-            return HttpResponse('COOL' if status == 200 else 'SWEATY', status=status)
+        def render_to_response(self, plugins, status_code):       # customize HTML output
+            return HttpResponse('COOL' if status_code == 200 else 'SWEATY', status=status_code)
 
-        def render_to_response_json(self, plugins, status):  # customize JSON output
+        def render_to_response_json(self, plugins, status_code):  # customize JSON output
             return JsonResponse(
-                {str(p.identifier()): 'COOL' if status == 200 else 'SWEATY' for p in plugins}
-                status=status
+                {str(p.identifier()): 'COOL' if status == 200 else 'SWEATY' for p in plugins},
+                status=status_code
             )
 
     # urls.py

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -46,8 +46,9 @@ to disable any of these checks, set its value to ``None``.
 .. code:: python
 
     HEALTH_CHECK = {
-        'DISK_USAGE_MAX': 90,  # percent
-        'MEMORY_MIN' = 100,    # in MB
+        'DISK_USAGE_MAX': 90,   # percent
+        'MEMORY_MIN' = 100,     # in MB
+        'JSON_VERBOSE' = False,
     }
 
 With the above default settings, warnings will be reported when disk utilization
@@ -62,3 +63,8 @@ exceeds 90% or available memory drops below 100 MB.
 
    Specify the desired memory utilization threshold, in megabytes. When available
    memory falls below the specified value, a warning will be reported.
+
+.. data:: JSON_VERBOSE
+
+   Specify whether or not additional details about each plugin (for instance,
+   response time) should also be emitted.

--- a/health_check/backends.py
+++ b/health_check/backends.py
@@ -11,6 +11,7 @@ logger = logging.getLogger('health-check')
 class BaseHealthCheckBackend:
     def __init__(self):
         self.errors = []
+        self.critical = True
 
     def check_status(self):
         raise NotImplementedError

--- a/health_check/views.py
+++ b/health_check/views.py
@@ -32,7 +32,7 @@ class MainView(TemplateView):
         status_code = 500 if errors else 200
 
         if 'application/json' in request.META.get('HTTP_ACCEPT', '') or self._is_setting_enabled(
-            'DISABLE_HTML_RENDERING', False):
+                'DISABLE_HTML_RENDERING', False):
             return self.render_to_response_json(plugins, status_code)
 
         context = {'plugins': plugins, 'status_code': status_code}

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -59,11 +59,11 @@ class TestMainView:
 
         class JSONSuccessBackend(BaseHealthCheckBackend):
             def run_check(self):
-                self.time_taken = 2.12345
+                self.time_taken = 2.1234567
 
         plugin_dir.reset()
         plugin_dir.register(JSONSuccessBackend)
         response = client.get(self.url, HTTP_ACCEPT='application/json')
         assert response.status_code == 200, response.content.decode('utf-8')
         assert json.loads(response.content.decode('utf-8')) == \
-               {JSONSuccessBackend().identifier(): {"status": JSONSuccessBackend().pretty_status(), "took": JSONSuccessBackend().time_taken}}
+               {JSONSuccessBackend().identifier(): {"status": JSONSuccessBackend().pretty_status(), "took": 2.1235}}

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -53,7 +53,9 @@ class TestMainView:
         assert 'JSON Error' in json.loads(response.content.decode('utf-8'))[JSONErrorBackend().identifier()]
 
     def test_success_json_verbose(self, client):
-        settings.HEALTH_CHECK["JSON_VERBOSE"] = True
+        settings.HEALTH_CHECK = {
+            "JSON_VERBOSE": True
+        }
 
         class JSONSuccessBackend(BaseHealthCheckBackend):
             def run_check(self):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,5 +1,7 @@
 import json
 
+from django.conf import settings
+
 from health_check.backends import BaseHealthCheckBackend
 from health_check.plugins import plugin_dir
 
@@ -49,3 +51,17 @@ class TestMainView:
         response = client.get(self.url, HTTP_ACCEPT='application/json')
         assert response.status_code == 500, response.content.decode('utf-8')
         assert 'JSON Error' in json.loads(response.content.decode('utf-8'))[JSONErrorBackend().identifier()]
+
+    def test_success_json_verbose(self, client):
+        settings.HEALTH_CHECK["JSON_VERBOSE"] = True
+
+        class JSONSuccessBackend(BaseHealthCheckBackend):
+            def run_check(self):
+                self.time_taken = 2.12345
+
+        plugin_dir.reset()
+        plugin_dir.register(JSONSuccessBackend)
+        response = client.get(self.url, HTTP_ACCEPT='application/json')
+        assert response.status_code == 200, response.content.decode('utf-8')
+        assert json.loads(response.content.decode('utf-8')) == \
+               {JSONSuccessBackend().identifier(): {"status": JSONSuccessBackend().pretty_status(), "took": JSONSuccessBackend().time_taken}}

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -66,4 +66,4 @@ class TestMainView:
         response = client.get(self.url, HTTP_ACCEPT='application/json')
         assert response.status_code == 200, response.content.decode('utf-8')
         assert json.loads(response.content.decode('utf-8')) == \
-               {JSONSuccessBackend().identifier(): {"status": JSONSuccessBackend().pretty_status(), "took": 2.1235}}
+            {JSONSuccessBackend().identifier(): {"status": JSONSuccessBackend().pretty_status(), "took": 2.1235}}


### PR DESCRIPTION
- Adding a `critical` flag to identify services that should not cause a health check failure
- Adding better JSON response (to include response time)