### PR TITLE
`critical` flag, better JSON response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 .coverage
 .eggs
 /docs/_build
+.pytest_cache

--- a/README.rst
+++ b/README.rst
@@ -158,6 +158,27 @@ The backend will return a JSON response:
 Optionally, the ``JSON_VERBOSE`` can be set to ``True`` in ``HEALTH_CHECK`` settings to output additional details about
 each plugin (for instance, response time).
 
+Overriding a health check
+-------------------------
+
+If you would like to customize an existing health check, for instance by changing its name or overriding its
+``critical`` flag, you can do so by adding something similar to the following to your own AppConfig.
+
+.. code:: python
+
+    from django.apps import AppConfig
+
+    from health_check.plugins import plugin_dir
+
+    class MyAppConfig(AppConfig):
+        name = 'my_app'
+
+        def ready(self):
+            from health_check.contrib.s3boto_storage.backends import S3BotoStorageBackend
+            plugin_dir.reregister(S3BotoStorageBackend.__name__,
+                                  type('S3Backend', (S3BotoStorageBackend,), {'critical': False}))
+
+
 Writing a custom health check
 -----------------------------
 

--- a/README.rst
+++ b/README.rst
@@ -155,7 +155,7 @@ The backend will return a JSON response:
         "S3BotoStorageHealthCheck": "working"
     }
 
-Optionally, the ``JSON_VERBOSE`` can be set to ``True`` in ``HEALTH_CHECK`` settings to output additional details about
+Optionally, the ``HEALTHCHECK_JSON_RESPONSE_ONLY`` can be set to ``True`` in settings to output additional details about
 each plugin (for instance, response time).
 
 Overriding a health check

--- a/README.rst
+++ b/README.rst
@@ -155,6 +155,9 @@ The backend will return a JSON response:
         "S3BotoStorageHealthCheck": "working"
     }
 
+Optionally, the ``JSON_VERBOSE`` can be set to ``True`` in ``HEALTH_CHECK`` settings to output additional details about
+each plugin (for instance, response time).
+
 Writing a custom health check
 -----------------------------
 
@@ -165,6 +168,15 @@ Writing a health check is quick and easy:
     from health_check.backends import BaseHealthCheckBackend
 
     class MyHealthCheckBackend(BaseHealthCheckBackend):
+        def __init__(self):
+            super().__init__()
+
+            # This flag indicates whether or not this plugin
+            # failing represents a critical health failure.
+            # If False,  a failure on this plugin will still
+            # allow a status_code of 200 to be returned
+            self.critical = False
+
         def check_status(self):
             # The test code goes here.
             # You can use `self.add_error` or
@@ -210,16 +222,16 @@ and customizing the ``template_name``, ``get``, ``render_to_response`` and ``ren
             plugins = []
             # ...
             if 'application/json' in request.META.get('HTTP_ACCEPT', ''):
-                return self.render_to_response_json(plugins, status)
-            return self.render_to_response(plugins, status)
+                return self.render_to_response_json(plugins, status_code)
+            return self.render_to_response(plugins, status_code)
 
-        def render_to_response(self, plugins, status):       # customize HTML output
-            return HttpResponse('COOL' if status == 200 else 'SWEATY', status=status)
+        def render_to_response(self, plugins, status_code):       # customize HTML output
+            return HttpResponse('COOL' if status_code == 200 else 'SWEATY', status=status_code)
 
-        def render_to_response_json(self, plugins, status):  # customize JSON output
+        def render_to_response_json(self, plugins, status_code):  # customize JSON output
             return JsonResponse(
-                {str(p.identifier()): 'COOL' if status == 200 else 'SWEATY' for p in plugins}
-                status=status
+                {str(p.identifier()): 'COOL' if status == 200 else 'SWEATY' for p in plugins},
+                status=status_code
             )
 
     # urls.py

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -48,7 +48,6 @@ to disable any of these checks, set its value to ``None``.
     HEALTH_CHECK = {
         'DISK_USAGE_MAX': 90,   # percent
         'MEMORY_MIN' = 100,     # in MB
-        'JSON_VERBOSE' = False,
     }
 
 With the above default settings, warnings will be reported when disk utilization
@@ -63,8 +62,3 @@ exceeds 90% or available memory drops below 100 MB.
 
    Specify the desired memory utilization threshold, in megabytes. When available
    memory falls below the specified value, a warning will be reported.
-
-.. data:: JSON_VERBOSE
-
-   Specify whether or not additional details about each plugin (for instance,
-   response time) should also be emitted.

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -46,8 +46,9 @@ to disable any of these checks, set its value to ``None``.
 .. code:: python
 
     HEALTH_CHECK = {
-        'DISK_USAGE_MAX': 90,  # percent
-        'MEMORY_MIN' = 100,    # in MB
+        'DISK_USAGE_MAX': 90,   # percent
+        'MEMORY_MIN' = 100,     # in MB
+        'JSON_VERBOSE' = False,
     }
 
 With the above default settings, warnings will be reported when disk utilization
@@ -62,3 +63,8 @@ exceeds 90% or available memory drops below 100 MB.
 
    Specify the desired memory utilization threshold, in megabytes. When available
    memory falls below the specified value, a warning will be reported.
+
+.. data:: JSON_VERBOSE
+
+   Specify whether or not additional details about each plugin (for instance,
+   response time) should also be emitted.

--- a/health_check/backends.py
+++ b/health_check/backends.py
@@ -11,7 +11,8 @@ logger = logging.getLogger('health-check')
 class BaseHealthCheckBackend:
     def __init__(self):
         self.errors = []
-        self.critical = True
+        if not hasattr(self, 'critical'):
+            self.critical = True
 
     def check_status(self):
         raise NotImplementedError

--- a/health_check/backends.py
+++ b/health_check/backends.py
@@ -11,8 +11,7 @@ logger = logging.getLogger('health-check')
 class BaseHealthCheckBackend:
     def __init__(self):
         self.errors = []
-        if not hasattr(self, 'critical'):
-            self.critical = True
+        self.critical = getattr(self, 'critical', True)
 
     def check_status(self):
         raise NotImplementedError

--- a/health_check/backends.py
+++ b/health_check/backends.py
@@ -11,6 +11,7 @@ logger = logging.getLogger('health-check')
 class BaseHealthCheckBackend:
     def __init__(self):
         self.errors = []
+        self.critical = True
 
     def check_status(self):
         raise NotImplementedError

--- a/health_check/contrib/celery/apps.py
+++ b/health_check/contrib/celery/apps.py
@@ -11,7 +11,7 @@ class HealthCheckConfig(AppConfig):
         from .backends import CeleryHealthCheck
 
         for queue in current_app.amqp.queues:
-            celery_class_name = CeleryHealthCheck.__class__.__name__ + queue.title()
+            celery_class_name = CeleryHealthCheck.__name__ + queue.title()
 
             celery_class = type(celery_class_name, (CeleryHealthCheck,), {'queue': queue})
             plugin_dir.register(celery_class)

--- a/health_check/contrib/celery/apps.py
+++ b/health_check/contrib/celery/apps.py
@@ -11,7 +11,7 @@ class HealthCheckConfig(AppConfig):
         from .backends import CeleryHealthCheck
 
         for queue in current_app.amqp.queues:
-            celery_class_name = 'CeleryHealthCheck' + queue.title()
+            celery_class_name = CeleryHealthCheck.__class__.__name__ + queue.title()
 
             celery_class = type(celery_class_name, (CeleryHealthCheck,), {'queue': queue})
             plugin_dir.register(celery_class)

--- a/health_check/plugins.py
+++ b/health_check/plugins.py
@@ -24,7 +24,7 @@ class HealthCheckPluginDirectory:
     def reregister(self, replace_class, new_plugin, **options):
         """Update the given plugin in the registry."""
         for i, value in enumerate(self._registry):
-            if value.__name__ == replace_class:
+            if value[0].__name__ == replace_class:
                 self._registry[i] = (new_plugin, options)
                 break
 

--- a/health_check/plugins.py
+++ b/health_check/plugins.py
@@ -21,5 +21,12 @@ class HealthCheckPluginDirectory:
         # Instantiate the admin class to save in the registry
         self._registry.append((plugin, options))
 
+    def reregister(self, replace_class, new_plugin, **options):
+        """Update the given plugin in the registry."""
+        for i, value in enumerate(self._registry):
+            if value.__name__ == replace_class:
+                self._registry[i] = (new_plugin, options)
+                break
+
 
 plugin_dir = HealthCheckPluginDirectory()

--- a/health_check/views.py
+++ b/health_check/views.py
@@ -31,8 +31,7 @@ class MainView(TemplateView):
 
         status_code = 500 if errors else 200
 
-        if 'application/json' in request.META.get('HTTP_ACCEPT', '') or self._is_setting_enabled(
-                'DISABLE_HTML_RENDERING', False):
+        if 'application/json' in request.META.get('HTTP_ACCEPT', '') or getattr(settings, 'HEALTHCHECK_JSON_RESPONSE_ONLY', False):
             return self.render_to_response_json(plugins, status_code)
 
         context = {'plugins': plugins, 'status_code': status_code}
@@ -40,7 +39,7 @@ class MainView(TemplateView):
         return self.render_to_response(context, status=status_code)
 
     def render_to_response_json(self, plugins, status_code):
-        if self._is_setting_enabled('JSON_VERBOSE', False):
+        if self._is_setting_enabled('HEALTHCHECK_JSON_STATUS', False):
             return JsonResponse(
                 {
                     str(p.identifier()): {

--- a/health_check/views.py
+++ b/health_check/views.py
@@ -31,7 +31,8 @@ class MainView(TemplateView):
 
         status_code = 500 if errors else 200
 
-        if 'application/json' in request.META.get('HTTP_ACCEPT', '') or getattr(settings, 'HEALTHCHECK_JSON_RESPONSE_ONLY', False):
+        if 'application/json' in request.META.get('HTTP_ACCEPT', '') or \
+           getattr(settings, 'HEALTHCHECK_JSON_RESPONSE_ONLY', False):
             return self.render_to_response_json(plugins, status_code)
 
         context = {'plugins': plugins, 'status_code': status_code}
@@ -39,7 +40,7 @@ class MainView(TemplateView):
         return self.render_to_response(context, status=status_code)
 
     def render_to_response_json(self, plugins, status_code):
-        if self._is_setting_enabled('HEALTHCHECK_JSON_STATUS', False):
+        if getattr(settings, 'HEALTHCHECK_JSON_STATUS', False):
             return JsonResponse(
                 {
                     str(p.identifier()): {
@@ -62,9 +63,3 @@ class MainView(TemplateView):
         finally:
             from django.db import connection
             connection.close()
-
-    def _is_setting_enabled(self, setting, default):
-        if hasattr(settings, 'HEALTH_CHECK'):
-            return settings.HEALTH_CHECK.get(setting, default)
-        else:
-            return default

--- a/health_check/views.py
+++ b/health_check/views.py
@@ -32,7 +32,7 @@ class MainView(TemplateView):
         status_code = 500 if errors else 200
 
         if 'application/json' in request.META.get('HTTP_ACCEPT', '') or self._is_setting_enabled(
-            'DISABLE_HTML_RENDERING', False):
+                'DISABLE_HTML_RENDERING', False):
             return self.render_to_response_json(plugins, status_code)
 
         context = {'plugins': plugins, 'status_code': status_code}

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -53,9 +53,7 @@ class TestMainView:
         assert 'JSON Error' in json.loads(response.content.decode('utf-8'))[JSONErrorBackend().identifier()]
 
     def test_success_json_verbose(self, client):
-        settings.HEALTH_CHECK = {
-            "HEALTHCHECK_JSON_STATUS": True
-        }
+        settings.HEALTHCHECK_JSON_STATUS = True
 
         class JSONSuccessBackend(BaseHealthCheckBackend):
             def run_check(self):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -54,7 +54,7 @@ class TestMainView:
 
     def test_success_json_verbose(self, client):
         settings.HEALTH_CHECK = {
-            "JSON_VERBOSE": True
+            "HEALTHCHECK_JSON_STATUS": True
         }
 
         class JSONSuccessBackend(BaseHealthCheckBackend):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -59,11 +59,11 @@ class TestMainView:
 
         class JSONSuccessBackend(BaseHealthCheckBackend):
             def run_check(self):
-                self.time_taken = 2.12345
+                self.time_taken = 2.1234567
 
         plugin_dir.reset()
         plugin_dir.register(JSONSuccessBackend)
         response = client.get(self.url, HTTP_ACCEPT='application/json')
         assert response.status_code == 200, response.content.decode('utf-8')
         assert json.loads(response.content.decode('utf-8')) == \
-               {JSONSuccessBackend().identifier(): {"status": JSONSuccessBackend().pretty_status(), "took": JSONSuccessBackend().time_taken}}
+               {JSONSuccessBackend().identifier(): {"status": JSONSuccessBackend().pretty_status(), "took": 2.1235}}

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -53,7 +53,9 @@ class TestMainView:
         assert 'JSON Error' in json.loads(response.content.decode('utf-8'))[JSONErrorBackend().identifier()]
 
     def test_success_json_verbose(self, client):
-        settings.HEALTH_CHECK["JSON_VERBOSE"] = True
+        settings.HEALTH_CHECK = {
+            "JSON_VERBOSE": True
+        }
 
         class JSONSuccessBackend(BaseHealthCheckBackend):
             def run_check(self):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,5 +1,7 @@
 import json
 
+from django.conf import settings
+
 from health_check.backends import BaseHealthCheckBackend
 from health_check.plugins import plugin_dir
 
@@ -49,3 +51,17 @@ class TestMainView:
         response = client.get(self.url, HTTP_ACCEPT='application/json')
         assert response.status_code == 500, response.content.decode('utf-8')
         assert 'JSON Error' in json.loads(response.content.decode('utf-8'))[JSONErrorBackend().identifier()]
+
+    def test_success_json_verbose(self, client):
+        settings.HEALTH_CHECK["JSON_VERBOSE"] = True
+
+        class JSONSuccessBackend(BaseHealthCheckBackend):
+            def run_check(self):
+                self.time_taken = 2.12345
+
+        plugin_dir.reset()
+        plugin_dir.register(JSONSuccessBackend)
+        response = client.get(self.url, HTTP_ACCEPT='application/json')
+        assert response.status_code == 200, response.content.decode('utf-8')
+        assert json.loads(response.content.decode('utf-8')) == \
+               {JSONSuccessBackend().identifier(): {"status": JSONSuccessBackend().pretty_status(), "took": JSONSuccessBackend().time_taken}}

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -66,4 +66,4 @@ class TestMainView:
         response = client.get(self.url, HTTP_ACCEPT='application/json')
         assert response.status_code == 200, response.content.decode('utf-8')
         assert json.loads(response.content.decode('utf-8')) == \
-               {JSONSuccessBackend().identifier(): {"status": JSONSuccessBackend().pretty_status(), "took": 2.1235}}
+            {JSONSuccessBackend().identifier(): {"status": JSONSuccessBackend().pretty_status(), "took": 2.1235}}


### PR DESCRIPTION
- Adding a `critical` flag to identify services that should not cause a health check failure
- Adding better JSON response (to include response time)
- Adding to README code example to reinit a backend so it can be renamed and have its default flags changed (for instance, the new `critical` flag)