### PR TITLE
Add support for warnings that do not error endpoints

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -165,6 +165,10 @@ Writing a health check is quick and easy:
     from health_check.backends import BaseHealthCheckBackend
 
     class MyHealthCheckBackend(BaseHealthCheckBackend):
+        #: The status endpoints will respond with a 200 status code
+        #: even if the check errors.
+        critical_service = False
+
         def check_status(self):
             # The test code goes here.
             # You can use `self.add_error` or

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -3,6 +3,13 @@ Settings
 
 Settings can be configured via the ``HEALTH_CHECK`` dictionary.
 
+.. data:: WARNINGS_AS_ERRORS
+
+    Treats :class:`ServiceWarning` as errors, meaning they will case the views
+    to respond with a 500 status code. Default is ``True``. If set to
+    ``False`` warnings will be displayed in the template on in the JSON
+    response but the status code will remain a 200.
+
 Security
 --------
 

--- a/health_check/backends.py
+++ b/health_check/backends.py
@@ -9,6 +9,14 @@ logger = logging.getLogger('health-check')
 
 
 class BaseHealthCheckBackend:
+    critical_service = True
+    """
+    Define if service is critical to the operation of the site.
+
+    If set to ``False`` service failures will cause a 500 response code on the
+    health check endpoint.
+    """
+
     def __init__(self):
         self.errors = []
 

--- a/health_check/conf.py
+++ b/health_check/conf.py
@@ -1,0 +1,6 @@
+from django.conf import settings
+
+HEALTH_CHECK = getattr(settings, 'HEALTH_CHECK', {})
+HEALTH_CHECK.setdefault('DISK_USAGE_MAX', 90)
+HEALTH_CHECK.setdefault('MEMORY_MIN', 100)
+HEALTH_CHECK.setdefault('WARNINGS_AS_ERRORS', True)

--- a/health_check/contrib/psutil/backends.py
+++ b/health_check/contrib/psutil/backends.py
@@ -2,21 +2,17 @@ import locale
 import socket
 
 import psutil
-from django.conf import settings
 
 from health_check.backends import BaseHealthCheckBackend
+from health_check.conf import HEALTH_CHECK
 from health_check.exceptions import (
     ServiceReturnedUnexpectedResult, ServiceWarning
 )
 
 host = socket.gethostname()
 
-if hasattr(settings, 'HEALTH_CHECK'):
-    DISK_USAGE_MAX = settings.HEALTH_CHECK.get('DISK_USAGE_MAX', 90)  # in %
-    MEMORY_MIN = settings.HEALTH_CHECK.get('MEMORY_MIN', 100)  # in MB
-else:
-    DISK_USAGE_MAX = 90  # in %
-    MEMORY_MIN = 100  # in MB
+DISK_USAGE_MAX = HEALTH_CHECK['DISK_USAGE_MAX']
+MEMORY_MIN = HEALTH_CHECK['MEMORY_MIN']
 
 
 class DiskUsage(BaseHealthCheckBackend):

--- a/health_check/exceptions.py
+++ b/health_check/exceptions.py
@@ -12,6 +12,13 @@ class HealthCheckException(Exception):
 
 
 class ServiceWarning(HealthCheckException):
+    """
+    Warning of service misbehavior.
+
+    If the ``HEALTH_CHECK['WARNINGS_AS_ERRORS']`` is set to ``False``,
+    these exceptions will not case a 500 status response.
+    """
+
     message_type = _("warning")
 
 

--- a/health_check/views.py
+++ b/health_check/views.py
@@ -1,15 +1,13 @@
 import copy
 from concurrent.futures import ThreadPoolExecutor
 
-from django.conf import settings
 from django.http import JsonResponse
 from django.views.decorators.cache import never_cache
 from django.views.generic import TemplateView
 
+from health_check.conf import HEALTH_CHECK
 from health_check.exceptions import ServiceWarning
 from health_check.plugins import plugin_dir
-
-WARNINGS_AS_ERRORS = getattr(settings, 'HEALTH_CHECK_WARNINGS_AS_ERRORS', True)
 
 
 class MainView(TemplateView):
@@ -35,7 +33,7 @@ class MainView(TemplateView):
         with ThreadPoolExecutor(max_workers=len(plugins) or 1) as executor:
             for plugin_errors, plugin in executor.map(_run, plugins):
                 if plugin.critical_service:
-                    if not WARNINGS_AS_ERRORS:
+                    if not HEALTH_CHECK['WARNINGS_AS_ERRORS']:
                         plugin_errors = (
                             e for e in plugin_errors
                             if not isinstance(e, ServiceWarning)


### PR DESCRIPTION
Add a new concept of warnings and non-critical services. Both
will not cause the template and JSON endpoint to response with a
500 status code but with a regular 200. This change is backwards
compatible because the existing warnings are treated as errors by
default.

Close #191