### PR TITLE
Add connection error exception for cache backend

### DIFF
--- a/health_check/cache/backends.py
+++ b/health_check/cache/backends.py
@@ -18,5 +18,3 @@ class CacheBackend(BaseHealthCheckBackend):
             self.add_error(ServiceReturnedUnexpectedResult("ValueError"), e)
         except ConnectionError as e:
             self.add_error(ServiceReturnedUnexpectedResult("Connection Error"), e)
-        except Exception as e:
-            self.add_error(ServiceReturnedUnexpectedResult("Exception"), e)

--- a/health_check/cache/backends.py
+++ b/health_check/cache/backends.py
@@ -16,3 +16,7 @@ class CacheBackend(BaseHealthCheckBackend):
             self.add_error(ServiceReturnedUnexpectedResult("Cache key warning"), e)
         except ValueError as e:
             self.add_error(ServiceReturnedUnexpectedResult("ValueError"), e)
+        except ConnectionError as e:
+            self.add_error(ServiceReturnedUnexpectedResult("Connection Error"), e)
+        except Exception as e:
+            self.add_error(ServiceReturnedUnexpectedResult("Exception"), e)


### PR DESCRIPTION
Just wondering if it would be a good idea to catch a connection error. I ran into an issue where it would spit back a malformed response because the exception wasn't being caught. Could probably also be added to the other checks if it's accepted here.