### PR TITLE
StorageHealthCheck - problem with overwriting file_name by some backends

### DIFF
--- a/health_check/storage/backends.py
+++ b/health_check/storage/backends.py
@@ -53,6 +53,7 @@ class StorageHealthCheck(BaseHealthCheckBackend):
         with storage.open(file_name) as f:
             if not f.read() == file_content:
                 raise ServiceUnavailable('File content does not match')
+        return file_name
 
     def check_delete(self, file_name):
         storage = self.get_storage()
@@ -66,7 +67,7 @@ class StorageHealthCheck(BaseHealthCheckBackend):
             # write the file to the storage backend
             file_name = self.get_file_name()
             file_content = self.get_file_content()
-            self.check_save(file_name, file_content)
+            file_name = self.check_save(file_name, file_content)
             self.check_delete(file_name)
             return True
         except Exception:


### PR DESCRIPTION
There is an issue when some storage backend overwrites requested file_name to something else (for ex. avoiding duplicates) - and when it happens there is a problem with this backend implementation. Please look at this method on StorageHealthCheck

```def check_save(self, file_name, file_content):
        storage = self.get_storage()
        # save the file
        file_name = storage.save(
            file_name, ContentFile(content=file_content)
        )
        # read the file and compare
        if not storage.exists(file_name):
            raise ServiceUnavailable('File does not exist')
        with storage.open(file_name) as f:
            if not f.read() == file_content:
                raise ServiceUnavailable('File content does not match')
```

Look at this line:

```
file_name = storage.save(
    file_name, ContentFile(content=file_content)
)
```

storage is allowed to overwrite the requested file_name - which is OK, and later the rest of code for this method is also OK - but since then this "file_name" may change.

Thats why this method:

```
def check_status(self):
        try:
            # write the file to the storage backend
            file_name = self.get_file_name()
            file_content = self.get_file_content()
            self.check_save(file_name, file_content)
            self.check_delete(file_name)
            return True
        except Exception:
            raise ServiceUnavailable('Unknown exception')
```

may not work OK because 'check_save' and 'check_delete' uses the "original" requested **file_name** - but as we've seen this "file_name" could be overwritten by `check_save` method - making method `check_delete` looking for invalid file_name.

It could be fixed by adding "return file_name" to "check_save" method, like this:

```
def check_save(self, file_name, file_content):
        storage = self.get_storage()
        # save the file
        file_name = storage.save(
            file_name, ContentFile(content=file_content)
        )
        # read the file and compare
        if not storage.exists(file_name):
            raise ServiceUnavailable('File does not exist')
        with storage.open(file_name) as f:
            if not f.read() == file_content:
                raise ServiceUnavailable('File content does not match')
        return file_name
```

And use that file name in `check_status` method:

```
def check_status(self):
        try:
            # write the file to the storage backend
            file_name = self.get_file_name()
            file_content = self.get_file_content()
            file_name = self.check_save(file_name, file_content)
            self.check_delete(file_name)
            return True
        except Exception:
            raise ServiceUnavailable('Unknown exception')
```

What do you think?



