### PR TITLE
Add a NotImplementedError warning to celery health check.

### DIFF
--- a/health_check/contrib/celery/backends.py
+++ b/health_check/contrib/celery/backends.py
@@ -24,6 +24,6 @@ class CeleryHealthCheck(BaseHealthCheckBackend):
         except IOError as e:
             self.add_error(ServiceUnavailable("IOError"), e)
         except NotImplementedError as e:
-            self.add_error(ServiceUnavailable("NotImplementedError: Have you set your CELERY_RESULT_BACKEND?"), e)
+            self.add_error(ServiceUnavailable("NotImplementedError: Make sure CELERY_RESULT_BACKEND is set"), e)
         except BaseException as e:
             self.add_error(ServiceUnavailable("Unknown error"), e)

--- a/health_check/contrib/celery/backends.py
+++ b/health_check/contrib/celery/backends.py
@@ -23,5 +23,7 @@ class CeleryHealthCheck(BaseHealthCheckBackend):
                 self.add_error(ServiceReturnedUnexpectedResult("Celery returned wrong result"))
         except IOError as e:
             self.add_error(ServiceUnavailable("IOError"), e)
+        except NotImplementedError as e:
+            self.add_error(ServiceUnavailable("NotImplementedError: Have you set your CELERY_RESULT_BACKEND?"), e)
         except BaseException as e:
             self.add_error(ServiceUnavailable("Unknown error"), e)


### PR DESCRIPTION
This can be triggered if the result backend isn't set which unfortunately took a long time for me to sort out because the error message was so ambiguous.