### PR TITLE
Fix a code comment that was misleading concenring critical services

### DIFF
--- a/health_check/backends.py
+++ b/health_check/backends.py
@@ -13,7 +13,7 @@ class BaseHealthCheckBackend:
     """
     Define if service is critical to the operation of the site.
 
-    If set to ``False`` service failures will cause a 500 response code on the
+    If set to ``True`` service failures return 500 response code on the
     health check endpoint.
     """
 


### PR DESCRIPTION
I noticed this comment which I think was wrong.

* If the service is critical, it's returning 500 when the check fails.
* If the service is not critical, it's returning 200 even when the check fails

I confirmed this as part of #206 ;)