### PR TITLE
created new health check for celery (celery ping)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -70,6 +70,7 @@ Add the ``health_check`` applications to your ``INSTALLED_APPS``:
         'health_check.cache',
         'health_check.storage',
         'health_check.contrib.celery',              # requires celery
+        'health_check.contrib.celery_ping',         # requires celery
         'health_check.contrib.psutil',              # disk and memory utilization; requires psutil
         'health_check.contrib.s3boto_storage',      # requires boto and S3BotoStorage backend
         'health_check.contrib.rabbitmq',            # requires RabbitMQ broker

--- a/health_check/contrib/celery_ping/__init__.py
+++ b/health_check/contrib/celery_ping/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'health_check.contrib.celery_ping.apps.HealthCheckConfig'

--- a/health_check/contrib/celery_ping/apps.py
+++ b/health_check/contrib/celery_ping/apps.py
@@ -1,0 +1,12 @@
+from django.apps import AppConfig
+
+from health_check.plugins import plugin_dir
+
+
+class HealthCheckConfig(AppConfig):
+    name = 'health_check.contrib.celery_ping'
+
+    def ready(self):
+        from .backends import CeleryPingHealthCheck
+
+        plugin_dir.register(CeleryPingHealthCheck)

--- a/health_check/contrib/celery_ping/backends.py
+++ b/health_check/contrib/celery_ping/backends.py
@@ -1,12 +1,8 @@
 from django.conf import settings
 
+from celery.app import default_app as app
 from health_check.backends import BaseHealthCheckBackend
 from health_check.exceptions import ServiceUnavailable
-
-try:
-    from celery.app import default_app as app
-except ImportError:
-    from celery import current_app as app
 
 
 class CeleryPingHealthCheck(BaseHealthCheckBackend):

--- a/health_check/contrib/celery_ping/backends.py
+++ b/health_check/contrib/celery_ping/backends.py
@@ -1,6 +1,6 @@
+from celery.app import default_app as app
 from django.conf import settings
 
-from celery.app import default_app as app
 from health_check.backends import BaseHealthCheckBackend
 from health_check.exceptions import ServiceUnavailable
 

--- a/health_check/contrib/celery_ping/backends.py
+++ b/health_check/contrib/celery_ping/backends.py
@@ -1,0 +1,33 @@
+from django.conf import settings
+
+try:
+    from celery.app import default_app as app
+except ImportError:
+    from celery import current_app as app
+
+from health_check.backends import BaseHealthCheckBackend
+from health_check.exceptions import ServiceUnavailable
+
+
+class CeleryPingHealthCheck(BaseHealthCheckBackend):
+
+    def check_status(self):
+        timeout = getattr(settings, 'HEALTHCHECK_CELERY_PING_TIMEOUT', 1)
+        try:
+            ping_result = app.control.ping(timeout=timeout)
+        except IOError as e:
+            self.add_error(ServiceUnavailable('IOError'), e)
+        except NotImplementedError as exc:
+            self.add_error(
+                ServiceUnavailable(
+                    'NotImplementedError: Make sure CELERY_RESULT_BACKEND is set'
+                ),
+                exc,
+            )
+        except BaseException as exc:
+            self.add_error(ServiceUnavailable('Unknown error'), exc)
+        else:
+            if not ping_result:
+                self.add_error(
+                    ServiceUnavailable('Celery workers unavailable'),
+                )

--- a/health_check/contrib/celery_ping/backends.py
+++ b/health_check/contrib/celery_ping/backends.py
@@ -1,12 +1,12 @@
 from django.conf import settings
 
+from health_check.backends import BaseHealthCheckBackend
+from health_check.exceptions import ServiceUnavailable
+
 try:
     from celery.app import default_app as app
 except ImportError:
     from celery import current_app as app
-
-from health_check.backends import BaseHealthCheckBackend
-from health_check.exceptions import ServiceUnavailable
 
 
 class CeleryPingHealthCheck(BaseHealthCheckBackend):

--- a/tests/test_autodiscover.py
+++ b/tests/test_autodiscover.py
@@ -7,17 +7,19 @@ from health_check.plugins import plugin_dir
 
 
 class TestAutoDiscover:
+
     def test_autodiscover(self):
         health_check_plugins = list(filter(
-            lambda x: 'health_check.' in x and 'celery' or 'celery_ping' not in x,
+            lambda x: x.startswith('health_check.') and 'celery' not in x,
             settings.INSTALLED_APPS
         ))
 
-        non_celery_plugins = [x for x in plugin_dir._registry if not issubclass(x[0], (CeleryHealthCheck, CeleryPingHealthCheck))]
+        non_celery_plugins = [x for x in plugin_dir._registry
+                              if not issubclass(x[0], (CeleryHealthCheck, CeleryPingHealthCheck))]
 
         # The number of installed apps excluding celery should equal to all plugins except celery
         assert len(non_celery_plugins) == len(health_check_plugins)
 
     def test_discover_celery_queues(self):
-        celery_plugins = [x for x in plugin_dir._registry if issubclass(x[0], (CeleryHealthCheck, CeleryPingHealthCheck))]
-        assert len(celery_plugins) == 2
+        celery_plugins = [x for x in plugin_dir._registry if issubclass(x[0], CeleryHealthCheck)]
+        assert len(celery_plugins) == len(current_app.amqp.queues)

--- a/tests/test_autodiscover.py
+++ b/tests/test_autodiscover.py
@@ -2,21 +2,22 @@ from celery import current_app
 from django.conf import settings
 
 from health_check.contrib.celery.backends import CeleryHealthCheck
+from health_check.contrib.celery_ping.backends import CeleryPingHealthCheck
 from health_check.plugins import plugin_dir
 
 
 class TestAutoDiscover:
     def test_autodiscover(self):
         health_check_plugins = list(filter(
-            lambda x: 'health_check.' in x and 'celery' not in x,
+            lambda x: 'health_check.' in x and 'celery' or 'celery_ping' not in x,
             settings.INSTALLED_APPS
         ))
 
-        non_celery_plugins = [x for x in plugin_dir._registry if not issubclass(x[0], CeleryHealthCheck)]
+        non_celery_plugins = [x for x in plugin_dir._registry if not issubclass(x[0], (CeleryHealthCheck, CeleryPingHealthCheck))]
 
         # The number of installed apps excluding celery should equal to all plugins except celery
         assert len(non_celery_plugins) == len(health_check_plugins)
 
     def test_discover_celery_queues(self):
-        celery_plugins = [x for x in plugin_dir._registry if issubclass(x[0], CeleryHealthCheck)]
-        assert len(celery_plugins) == len(current_app.amqp.queues)
+        celery_plugins = [x for x in plugin_dir._registry if issubclass(x[0], (CeleryHealthCheck, CeleryPingHealthCheck))]
+        assert len(celery_plugins) == 2

--- a/tests/test_celery_ping.py
+++ b/tests/test_celery_ping.py
@@ -1,0 +1,72 @@
+import pytest
+
+from health_checks.contrib.celery_ping.backends import CeleryPingHealthCheck
+
+CELERY_HEALTH_CHECK_MODULE = 'apps.health_checks.backends.celery.'
+
+
+class TestCeleryWorkersHealthCheck:
+    health_check_class = CeleryPingHealthCheck
+    CELERY_HEALTH_CHECK_MODULE = \
+        'health_checks.contrib.celery_ping.backends.app.control.ping'
+
+    def test_check_status_doesnt_add_errors_when_ping_successfull(
+            self, mocker):
+        mocker.patch(
+            self.CELERY_HEALTH_CHECK_MODULE,
+            return_value=[{'celery@4cc150a7b49b': {'ok': 'pong'}}])
+
+        health_check = self.health_check_class()
+        health_check.check_status()
+
+        assert len(health_check.errors) == 0
+
+    @pytest.mark.parametrize('exception_to_raise', [
+        IOError,
+        TimeoutError,
+    ])
+    def test_check_status_add_error_when_io_error_raised_from_ping(
+            self, mocker, exception_to_raise):
+        mocker.patch(
+            self.CELERY_HEALTH_CHECK_MODULE,
+            side_effect=exception_to_raise)
+
+        health_check = self.health_check_class()
+        health_check.check_status()
+
+        assert len(health_check.errors) == 1
+        assert 'ioerror' in health_check.errors[0].message.lower()
+
+    @pytest.mark.parametrize('exception_to_raise', [
+        ValueError,
+        SystemError,
+        IndexError,
+        MemoryError,
+    ])
+    def test_check_status_add_error_when_any_exception_raised_from_ping(
+            self, mocker, exception_to_raise):
+        mocker.patch(
+            self.CELERY_HEALTH_CHECK_MODULE,
+            side_effect=exception_to_raise)
+
+        health_check = self.health_check_class()
+        health_check.check_status()
+
+        assert len(health_check.errors) == 1
+        assert health_check.errors[0].message.lower() == 'unknown error'
+
+    @pytest.mark.parametrize('ping_result', [
+        None,
+        list()
+    ])
+    def test_check_status_add_error_when_ping_result_failed(
+            self, mocker, ping_result):
+        mocker.patch(
+            self.CELERY_HEALTH_CHECK_MODULE,
+            return_value=ping_result)
+
+        health_check = self.health_check_class()
+        health_check.check_status()
+
+        assert len(health_check.errors) == 1
+        assert 'workers unavailable' in health_check.errors[0].message.lower()

--- a/tests/test_celery_ping.py
+++ b/tests/test_celery_ping.py
@@ -1,7 +1,7 @@
 import pytest
+from mock import patch
 
 from health_check.contrib.celery_ping.backends import CeleryPingHealthCheck
-from mock import patch
 
 
 class TestCeleryWorkersHealthCheck:

--- a/tests/test_celery_ping.py
+++ b/tests/test_celery_ping.py
@@ -1,6 +1,7 @@
 import pytest
 
 from health_check.contrib.celery_ping.backends import CeleryPingHealthCheck
+from mock import patch
 
 
 class TestCeleryWorkersHealthCheck:
@@ -8,32 +9,27 @@ class TestCeleryWorkersHealthCheck:
     CELERY_HEALTH_CHECK_MODULE = \
         'health_check.contrib.celery_ping.backends.app.control.ping'
 
-    def test_check_status_doesnt_add_errors_when_ping_successfull(
-            self, mocker):
-        mocker.patch(
-            self.CELERY_HEALTH_CHECK_MODULE,
-            return_value=[{'celery@4cc150a7b49b': {'ok': 'pong'}}])
+    def test_check_status_doesnt_add_errors_when_ping_successfull(self):
+        with patch(self.CELERY_HEALTH_CHECK_MODULE,
+                   return_value=[{'celery@4cc150a7b49b': {'ok': 'pong'}}]):
+            health_check = self.health_check_class()
+            health_check.check_status()
 
-        health_check = self.health_check_class()
-        health_check.check_status()
-
-        assert len(health_check.errors) == 0
+            assert len(health_check.errors) == 0
 
     @pytest.mark.parametrize('exception_to_raise', [
         IOError,
         TimeoutError,
     ])
     def test_check_status_add_error_when_io_error_raised_from_ping(
-            self, mocker, exception_to_raise):
-        mocker.patch(
-            self.CELERY_HEALTH_CHECK_MODULE,
-            side_effect=exception_to_raise)
+            self, exception_to_raise):
+        with patch(self.CELERY_HEALTH_CHECK_MODULE,
+                   side_effect=exception_to_raise):
+            health_check = self.health_check_class()
+            health_check.check_status()
 
-        health_check = self.health_check_class()
-        health_check.check_status()
-
-        assert len(health_check.errors) == 1
-        assert 'ioerror' in health_check.errors[0].message.lower()
+            assert len(health_check.errors) == 1
+            assert 'ioerror' in health_check.errors[0].message.lower()
 
     @pytest.mark.parametrize('exception_to_raise', [
         ValueError,
@@ -42,29 +38,25 @@ class TestCeleryWorkersHealthCheck:
         MemoryError,
     ])
     def test_check_status_add_error_when_any_exception_raised_from_ping(
-            self, mocker, exception_to_raise):
-        mocker.patch(
-            self.CELERY_HEALTH_CHECK_MODULE,
-            side_effect=exception_to_raise)
+            self, exception_to_raise):
+        with patch(self.CELERY_HEALTH_CHECK_MODULE,
+                   side_effect=exception_to_raise):
+            health_check = self.health_check_class()
+            health_check.check_status()
 
-        health_check = self.health_check_class()
-        health_check.check_status()
-
-        assert len(health_check.errors) == 1
-        assert health_check.errors[0].message.lower() == 'unknown error'
+            assert len(health_check.errors) == 1
+            assert health_check.errors[0].message.lower() == 'unknown error'
 
     @pytest.mark.parametrize('ping_result', [
         None,
         list()
     ])
     def test_check_status_add_error_when_ping_result_failed(
-            self, mocker, ping_result):
-        mocker.patch(
-            self.CELERY_HEALTH_CHECK_MODULE,
-            return_value=ping_result)
+            self, ping_result):
+        with patch(self.CELERY_HEALTH_CHECK_MODULE,
+                   return_value=ping_result):
+            health_check = self.health_check_class()
+            health_check.check_status()
 
-        health_check = self.health_check_class()
-        health_check.check_status()
-
-        assert len(health_check.errors) == 1
-        assert 'workers unavailable' in health_check.errors[0].message.lower()
+            assert len(health_check.errors) == 1
+            assert 'workers unavailable' in health_check.errors[0].message.lower()

--- a/tests/test_celery_ping.py
+++ b/tests/test_celery_ping.py
@@ -1,14 +1,12 @@
 import pytest
 
-from health_checks.contrib.celery_ping.backends import CeleryPingHealthCheck
-
-CELERY_HEALTH_CHECK_MODULE = 'apps.health_checks.backends.celery.'
+from health_check.contrib.celery_ping.backends import CeleryPingHealthCheck
 
 
 class TestCeleryWorkersHealthCheck:
     health_check_class = CeleryPingHealthCheck
     CELERY_HEALTH_CHECK_MODULE = \
-        'health_checks.contrib.celery_ping.backends.app.control.ping'
+        'health_check.contrib.celery_ping.backends.app.control.ping'
 
     def test_check_status_doesnt_add_errors_when_ping_successfull(
             self, mocker):

--- a/tests/test_celery_ping.py
+++ b/tests/test_celery_ping.py
@@ -1,10 +1,9 @@
-from django.apps import apps
-
 import pytest
+from django.apps import apps
+from mock import patch
 
 from health_check.contrib.celery_ping.apps import HealthCheckConfig
 from health_check.contrib.celery_ping.backends import CeleryPingHealthCheck
-from mock import patch
 
 
 class TestCeleryPingHealthCheck:

--- a/tests/testapp/settings.py
+++ b/tests/testapp/settings.py
@@ -23,6 +23,7 @@ INSTALLED_APPS = (
     'health_check.db',
     'health_check.storage',
     'health_check.contrib.celery',
+    'health_check.contrib.celery_ping',
     'health_check.contrib.s3boto_storage',
     'tests',
 )


### PR DESCRIPTION
Hi, your package for testing health app is awesome :) 
but some apps have a problem when testing celery module.
When app creates a lot of tasks in queue then testing celery by creating new task always return fault code. This extension give us possibility check that celery app work (i usage celery ping for that).