### PR TITLE
Adds 'app_name' to urlconf

### DIFF
--- a/health_check/backends.py
+++ b/health_check/backends.py
@@ -1,7 +1,7 @@
 import logging
 from timeit import default_timer as timer
 
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import ugettext_lazy as _  # noqa: N812
 
 from health_check.exceptions import HealthCheckException
 

--- a/health_check/exceptions.py
+++ b/health_check/exceptions.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import ugettext_lazy as _  # noqa: N812
 
 
 class HealthCheckException(Exception):

--- a/health_check/urls.py
+++ b/health_check/urls.py
@@ -2,6 +2,8 @@ from django.conf.urls import url
 
 from health_check.views import MainView
 
+app_name = 'health_check'
+
 urlpatterns = [
     url(r'^$', MainView.as_view(), name='health_check_home'),
 ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,5 +7,5 @@ mccabe
 mock
 pydocstyle
 pep8-naming
-pytest
+pytest<4
 pytest-django

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -12,7 +12,7 @@ except ImportError:
 
 
 class TestMainView:
-    url = reverse('health_check_home')
+    url = reverse('health_check:health_check_home')
 
     def test_success(self, client):
         response = client.get(self.url)


### PR DESCRIPTION
When using you app like so:

```python
from health_check import urls as health_urls

urlpatterns = [
    # Health checks:
    url(r'^health/', include(health_urls, namespace='health')),
]
```

Without this property I am getting this warning:

```
server/urls.py:32
  /Users/sobolev/Desktop/test_project/server/urls.py:32: RemovedInDjango20Warning: Specifying a namespace in django.conf.urls.include() without providing an app_name is deprecated. Set the app_name attribute in the included module, or pass a 2-tuple containing the list of patterns and app_name instead.
    url(r'^health/', include(health_urls, namespace='health')),

-- Docs: https://docs.pytest.org/en/latest/warnings.html
```

Related: https://stackoverflow.com/questions/48608894/specifying-a-namespace-in-include-without-providing-an-app-name