### PR TITLE
Test against more Django and Python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ env:
   - TOXENV=docs
   - DJANGO=111
   - DJANGO=20
+  - DJANGO=21
+  - DJANGO=22
   - DJANGO=master
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ matrix:
   - env: TOXENV=qa
   - env: TOXENV=docs
 
-  - env: DJANGO=111
   - env: DJANGO=21
 
   # Test the latest Django LTS release against all supported Pythons: 3.5, 3.6, 3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,33 +22,33 @@ matrix:
   - env: DJANGO=master
 
   include:
-    - env: TOXENV=qa
-    - env: TOXENV=docs
+  - env: TOXENV=qa
+  - env: TOXENV=docs
 
-    - env: DJANGO=111
-    - env: DJANGO=20
-    - env: DJANGO=21
+  - env: DJANGO=111
+  - env: DJANGO=20
+  - env: DJANGO=21
 
-    # Test the latest Django LTS release against all supported Pythons: 3.5, 3.6, 3.7
-    - env: DJANGO=22
-      python: '3.5'
-    - env: DJANGO=22
-      python: '3.6'
-    - env: DJANGO=22
-      python: '3.7'
+  # Test the latest Django LTS release against all supported Pythons: 3.5, 3.6, 3.7
+  - env: DJANGO=22
+    python: '3.5'
+  - env: DJANGO=22
+    python: '3.6'
+  - env: DJANGO=22
+    python: '3.7'
 
-    - env: DJANGO=master
+  - env: DJANGO=master
 
-    - stage: PyPI release  # will run after the default "test" stage succeeds
-      script: echo "Deploying to PyPI ..."  # override regular test script; "skip" should also work
-      if: tag IS present
-      deploy:
-        provider: pypi
-        user: codingjoe
-        password:
-          secure: jJyadofJm7F1Qco+EDCyN/aMZaYSbfQ0GAE02Bx7I499MkjPYvv38X2btg+PjdW3rzGD0d/kq24lfWLkgKncyQ/YMgLQ7H/GuCCHHYbKUklxllaoFXActBjstmKOvXyWWC5oEb+YEJ4HTwgkvS6wkp69B7C1d4BAOqGs5IKnCSo=
-        on:
-          tags: true
-          distributions: sdist bdist_wheel
-          repo: KristianOellegaard/django-health-check
-          branch: master
+  - stage: PyPI release  # will run after the default "test" stage succeeds
+    script: echo "Deploying to PyPI ..."  # override regular test script; "skip" should also work
+    if: tag IS present
+    deploy:
+      provider: pypi
+      user: codingjoe
+      password:
+        secure: jJyadofJm7F1Qco+EDCyN/aMZaYSbfQ0GAE02Bx7I499MkjPYvv38X2btg+PjdW3rzGD0d/kq24lfWLkgKncyQ/YMgLQ7H/GuCCHHYbKUklxllaoFXActBjstmKOvXyWWC5oEb+YEJ4HTwgkvS6wkp69B7C1d4BAOqGs5IKnCSo=
+      on:
+        tags: true
+        distributions: sdist bdist_wheel
+        repo: KristianOellegaard/django-health-check
+        branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,6 @@ matrix:
   - env: TOXENV=docs
 
   - env: DJANGO=111
-  - env: DJANGO=20
   - env: DJANGO=21
 
   # Test the latest Django LTS release against all supported Pythons: 3.5, 3.6, 3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,12 @@ matrix:
   - env: TOXENV=docs
 
   - env: DJANGO=21
+    python: '3.5'
+  - env: DJANGO=21
+    python: '3.6'
+  - env: DJANGO=21
+    python: '3.7'
 
-  # Test the latest Django LTS release against all supported Pythons: 3.5, 3.6, 3.7
   - env: DJANGO=22
     python: '3.5'
   - env: DJANGO=22

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,8 @@
 language: python
-sudo: false
+dist: xenial
 cache: pip
-python:
-- '3.6'
-env:
-  matrix:
-  - TOXENV=qa
-  - TOXENV=docs
-  - DJANGO=111
-  - DJANGO=20
-  - DJANGO=21
-  - DJANGO=22
-  - DJANGO=master
-matrix:
-  fast_finish: true
-  allow_failures:
-  - env: DJANGO=master
+python: '3.7'  # "Default" Python version
+
 install:
 - pip install --upgrade codecov tox
 before_script:
@@ -28,12 +15,32 @@ script:
 - tox -e $TOXENV
 after_success:
 - codecov
-jobs:
+
+matrix:
+  fast_finish: true
+  allow_failures:
+  - env: DJANGO=master
+
   include:
+    - env: TOXENV=qa
+    - env: TOXENV=docs
+
+    - env: DJANGO=111
+    - env: DJANGO=20
+    - env: DJANGO=21
+
+    # Test the latest Django LTS release against all supported Pythons: 3.5, 3.6, 3.7
+    - env: DJANGO=22
+      python: '3.5'
+    - env: DJANGO=22
+      python: '3.6'
+    - env: DJANGO=22
+      python: '3.7'
+
+    - env: DJANGO=master
+
     - stage: PyPI release  # will run after the default "test" stage succeeds
       script: echo "Deploying to PyPI ..."  # override regular test script; "skip" should also work
-      env:
-        - TOXENV=qa  # if not set explicitly, build matrix vars will use their first value
       if: tag IS present
       deploy:
         provider: pypi

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36}-dj{111,20,21,22,master},qa
+envlist = py{36}-dj{111,21,22,master},qa
 
 [testenv]
 setenv=
@@ -7,7 +7,6 @@ setenv=
 deps=
     -rrequirements-dev.txt
     dj111: Django>=1.11,<2.0
-    dj20: Django>=2.0,<2.1
     dj21: Django>=2.1,<2.2
     dj22: Django>=2.2,<2.3
     djmaster: https://github.com/django/django/archive/master.tar.gz#egg=django

--- a/tox.ini
+++ b/tox.ini
@@ -6,8 +6,10 @@ setenv=
     PYTHONPATH = {toxinidir}:$PYTHONPATH
 deps=
     -rrequirements-dev.txt
-    dj111: https://github.com/django/django/archive/stable/1.11.x.tar.gz#egg=django
-    dj20: https://github.com/django/django/archive/stable/2.0.x.tar.gz#egg=django
+    dj111: Django>=1.11,<2.0
+    dj20: Django>=2.0,<2.1
+    dj21: Django>=2.1,<2.2
+    dj22: Django>=2.2,<2.3
     djmaster: https://github.com/django/django/archive/master.tar.gz#egg=django
 commands=
     coverage run --source='health_check' -m 'pytest' \

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36}-dj{111,20,master},qa
+envlist = py{36}-dj{111,20,21,22,master},qa
 
 [testenv]
 setenv=


### PR DESCRIPTION
* Test against Django 2.1 & 2.2
* Install Django in tox environment from package rather than git archive
* Update default Python version in Travis to 3.7
* Test against all supported versions of Python for latest Django LTS release
* Slight Travis file cleanup (move matrix things all to one place, `jobs` is an alias for `matrix`)

This is a large-ish change to the Travis file I've made without any consultation, so I'd be totally OK if you wanted me to make fewer changes or to pick out some of these changes yourself.