### PR TITLE
Improve accept header handling for unknown types

### DIFF
--- a/health_check/views.py
+++ b/health_check/views.py
@@ -126,8 +126,7 @@ class MainView(TemplateView):
                 return self.render_to_response(context, status=status_code)
             elif media.mime_type in ('application/json', 'application/*'):
                 return self.render_to_response_json(plugins, status_code)
-            else:
-                return self.render_to_response(context, status=status_code)
+        return self.render_to_response(context, status=status_code)
 
     def render_to_response_json(self, plugins, status):
         return JsonResponse(

--- a/health_check/views.py
+++ b/health_check/views.py
@@ -2,8 +2,7 @@ import copy
 import re
 from concurrent.futures import ThreadPoolExecutor
 
-from django.http import JsonResponse
-from django.http import HttpResponse
+from django.http import HttpResponse, JsonResponse
 from django.views.decorators.cache import never_cache
 from django.views.generic import TemplateView
 

--- a/health_check/views.py
+++ b/health_check/views.py
@@ -3,6 +3,7 @@ import re
 from concurrent.futures import ThreadPoolExecutor
 
 from django.http import JsonResponse
+from django.http import HttpResponse
 from django.views.decorators.cache import never_cache
 from django.views.generic import TemplateView
 
@@ -126,7 +127,7 @@ class MainView(TemplateView):
                 return self.render_to_response(context, status=status_code)
             elif media.mime_type in ('application/json', 'application/*'):
                 return self.render_to_response_json(plugins, status_code)
-        return self.render_to_response(context, status=status_code)
+        return HttpResponse('Only HTML and JSON responses are supported', status=406, content_type='text/plain')
 
     def render_to_response_json(self, plugins, status):
         return JsonResponse(

--- a/health_check/views.py
+++ b/health_check/views.py
@@ -126,7 +126,7 @@ class MainView(TemplateView):
                 return self.render_to_response(context, status=status_code)
             elif media.mime_type in ('application/json', 'application/*'):
                 return self.render_to_response_json(plugins, status_code)
-        return HttpResponse('Only HTML and JSON responses are supported', status=406, content_type='text/plain')
+        return HttpResponse('Not Acceptable: Supported content types: text/html, application/json', status=406, content_type='text/plain')
 
     def render_to_response_json(self, plugins, status):
         return JsonResponse(

--- a/health_check/views.py
+++ b/health_check/views.py
@@ -126,7 +126,11 @@ class MainView(TemplateView):
                 return self.render_to_response(context, status=status_code)
             elif media.mime_type in ('application/json', 'application/*'):
                 return self.render_to_response_json(plugins, status_code)
-        return HttpResponse('Not Acceptable: Supported content types: text/html, application/json', status=406, content_type='text/plain')
+        return HttpResponse(
+            'Not Acceptable: Supported content types: text/html, application/json',
+            status=406,
+            content_type='text/plain'
+        )
 
     def render_to_response_json(self, plugins, status):
         return JsonResponse(

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -138,6 +138,7 @@ class TestMainView:
         plugin_dir.register(JSONSuccessBackend)
         response = client.get(self.url, HTTP_ACCEPT='application/json')
         assert response['content-type'] == 'application/json'
+        assert response.status_code == 200
 
     def test_success_prefer_json(self, client):
         class JSONSuccessBackend(BaseHealthCheckBackend):
@@ -148,6 +149,7 @@ class TestMainView:
         plugin_dir.register(JSONSuccessBackend)
         response = client.get(self.url, HTTP_ACCEPT='application/json; q=0.8, text/html; q=0.5')
         assert response['content-type'] == 'application/json'
+        assert response.status_code == 200
 
     def test_success_accept_xhtml(self, client):
         class SuccessBackend(BaseHealthCheckBackend):
@@ -158,6 +160,7 @@ class TestMainView:
         plugin_dir.register(SuccessBackend)
         response = client.get(self.url, HTTP_ACCEPT='application/xhtml+xml')
         assert response['content-type'] == 'text/html; charset=utf-8'
+        assert response.status_code == 200
 
     def test_success_unsupported_accept(self, client):
         class SuccessBackend(BaseHealthCheckBackend):
@@ -168,6 +171,7 @@ class TestMainView:
         plugin_dir.register(SuccessBackend)
         response = client.get(self.url, HTTP_ACCEPT='application/octet-stream')
         assert response['content-type'] == 'text/html; charset=utf-8'
+        assert response.status_code == 200
 
     def test_success_unsupported_and_supported_accept(self, client):
         class SuccessBackend(BaseHealthCheckBackend):
@@ -178,6 +182,7 @@ class TestMainView:
         plugin_dir.register(SuccessBackend)
         response = client.get(self.url, HTTP_ACCEPT='application/octet-stream, application/json; q=0.9')
         assert response['content-type'] == 'application/json'
+        assert response.status_code == 200
 
     def test_success_accept_order(self, client):
         class JSONSuccessBackend(BaseHealthCheckBackend):
@@ -191,6 +196,7 @@ class TestMainView:
             HTTP_ACCEPT='text/html, application/xhtml+xml, application/json; q=0.9, */*; q=0.1'
         )
         assert response['content-type'] == 'text/html; charset=utf-8'
+        assert response.status_code == 200
 
     def test_success_accept_order__reverse(self, client):
         class JSONSuccessBackend(BaseHealthCheckBackend):
@@ -201,6 +207,7 @@ class TestMainView:
         plugin_dir.register(JSONSuccessBackend)
         response = client.get(self.url, HTTP_ACCEPT='text/html; q=0.1, application/xhtml+xml; q=0.1, application/json')
         assert response['content-type'] == 'application/json'
+        assert response.status_code == 200
 
     def test_format_override(self, client):
         class JSONSuccessBackend(BaseHealthCheckBackend):
@@ -211,6 +218,7 @@ class TestMainView:
         plugin_dir.register(JSONSuccessBackend)
         response = client.get(self.url + '?format=json', HTTP_ACCEPT='text/html')
         assert response['content-type'] == 'application/json'
+        assert response.status_code == 200
 
     def test_format_no_accept_header(self, client):
         class JSONSuccessBackend(BaseHealthCheckBackend):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -172,7 +172,7 @@ class TestMainView:
         response = client.get(self.url, HTTP_ACCEPT='application/octet-stream')
         assert response['content-type'] == 'text/plain'
         assert response.status_code == 406
-        assert response.content == 'Only HTML and JSON responses are supported'
+        assert response.content == b'Only HTML and JSON responses are supported'
 
     def test_success_unsupported_and_supported_accept(self, client):
         class SuccessBackend(BaseHealthCheckBackend):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -172,7 +172,7 @@ class TestMainView:
         response = client.get(self.url, HTTP_ACCEPT='application/octet-stream')
         assert response['content-type'] == 'text/plain'
         assert response.status_code == 406
-        assert response.content == b'Only HTML and JSON responses are supported'
+        assert response.content == b'Not Acceptable: Supported content types: text/html, application/json'
 
     def test_success_unsupported_and_supported_accept(self, client):
         class SuccessBackend(BaseHealthCheckBackend):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -139,6 +139,16 @@ class TestMainView:
         response = client.get(self.url, HTTP_ACCEPT='application/json')
         assert response['content-type'] == 'application/json'
 
+    def test_success_prefer_json(self, client):
+        class JSONSuccessBackend(BaseHealthCheckBackend):
+            def run_check(self):
+                pass
+
+        plugin_dir.reset()
+        plugin_dir.register(JSONSuccessBackend)
+        response = client.get(self.url, HTTP_ACCEPT='application/json; q=0.8, text/html; q=0.5')
+        assert response['content-type'] == 'application/json'
+
     def test_success_accept_xhtml(self, client):
         class SuccessBackend(BaseHealthCheckBackend):
             def run_check(self):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -170,8 +170,9 @@ class TestMainView:
         plugin_dir.reset()
         plugin_dir.register(SuccessBackend)
         response = client.get(self.url, HTTP_ACCEPT='application/octet-stream')
-        assert response['content-type'] == 'text/html; charset=utf-8'
-        assert response.status_code == 200
+        assert response['content-type'] == 'text/plain'
+        assert response.status_code == 406
+        assert response.content == 'Only HTML and JSON responses are supported'
 
     def test_success_unsupported_and_supported_accept(self, client):
         class SuccessBackend(BaseHealthCheckBackend):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -169,6 +169,16 @@ class TestMainView:
         response = client.get(self.url, HTTP_ACCEPT='application/octet-stream')
         assert response['content-type'] == 'text/html; charset=utf-8'
 
+    def test_success_unsupported_and_supported_accept(self, client):
+        class SuccessBackend(BaseHealthCheckBackend):
+            def run_check(self):
+                pass
+
+        plugin_dir.reset()
+        plugin_dir.register(SuccessBackend)
+        response = client.get(self.url, HTTP_ACCEPT='application/octet-stream, application/json; q=0.9')
+        assert response['content-type'] == 'application/json'
+
     def test_success_accept_order(self, client):
         class JSONSuccessBackend(BaseHealthCheckBackend):
             def run_check(self):


### PR DESCRIPTION
In the project where I'm using this, I particularly care about the case where the request prefers other types but has a lower quality match for JSON, e.g.:

    Accept: application/x-unknown, application/json; q=0.1

At the moment, it resolves using the first entry in the sorted list of types, even if there are better matches later on.

Sorry I failed to spot this when reviewing the q-value changes for #216.