### PR TITLE
Health Check for Redis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ env:
   - DJANGO=111
   - DJANGO=22
   - DJANGO=master
+services:
+  - redis-server
 matrix:
   fast_finish: true
   allow_failures:

--- a/README.rst
+++ b/README.rst
@@ -73,6 +73,7 @@ Add the ``health_check`` applications to your ``INSTALLED_APPS``:
         'health_check.contrib.psutil',              # disk and memory utilization; requires psutil
         'health_check.contrib.s3boto_storage',      # requires boto and S3BotoStorage backend
         'health_check.contrib.rabbitmq',            # requires RabbitMQ broker
+        'health_check.contrib.redis',               # required Redis broker
     ]
 
 (Optional) If using the ``psutil`` app, you can configure disk and memory
@@ -99,6 +100,12 @@ on django.conf.settings with the required format to connect to your rabbit serve
 
     BROKER_URL = amqp://myuser:mypassword@localhost:5672/myvhost
 
+To use the Redis healthcheck, please make sure that there is a variable named ``REDIS_URL``
+on django.conf.settings with the required format to connect to your redis server. For example:
+
+.. code::
+
+    REDIS_URL = redis://localhost:6370
 
 Setting up monitoring
 ---------------------

--- a/health_check/contrib/redis/__init__.py
+++ b/health_check/contrib/redis/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'health_check.contrib.redis.apps.HealthCheckConfig'

--- a/health_check/contrib/redis/apps.py
+++ b/health_check/contrib/redis/apps.py
@@ -1,0 +1,12 @@
+from django.apps import AppConfig
+
+from health_check.plugins import plugin_dir
+
+
+class HealthCheckConfig(AppConfig):
+    name = "health_check.contrib.redis"
+
+    def ready(self):
+        from .backends import RedisHealthCheck
+
+        plugin_dir.register(RedisHealthCheck)

--- a/health_check/contrib/redis/backends.py
+++ b/health_check/contrib/redis/backends.py
@@ -12,10 +12,7 @@ logger = logging.getLogger(__name__)
 class RedisHealthCheck(BaseHealthCheckBackend):
     """Health check for Redis."""
 
-    def __init__(self):
-        super(RedisHealthCheck, self).__init__()
-        logger.debug("Checking for a redis_url in django settings...")
-        self.redis_url = getattr(settings, "REDIS_URL", None)
+    redis_url = getattr(settings, "REDIS_URL", 'redis://localhost/1')
 
     def check_status(self):
         """Check Redis service by pinging the redis instance with a redis connection."""

--- a/health_check/contrib/redis/backends.py
+++ b/health_check/contrib/redis/backends.py
@@ -24,10 +24,7 @@ class RedisHealthCheck(BaseHealthCheckBackend):
         try:
             # conn is used as a context to release opened resources later
             with from_url(redis_url) as conn:
-                print('conn', conn)
                 conn.ping()  # exceptions may be raised upon ping
-                print(conn.ping())
-                print('got here')
         except ConnectionRefusedError as e:
             self.add_error(ServiceUnavailable("Unable to connect to Redis: Connection was refused."), e)
         except exceptions.TimeoutError as e:

--- a/health_check/contrib/redis/backends.py
+++ b/health_check/contrib/redis/backends.py
@@ -12,8 +12,10 @@ logger = logging.getLogger(__name__)
 class RedisHealthCheck(BaseHealthCheckBackend):
     """Health check for Redis."""
 
-    logger.debug("Checking for a redis_url in django settings...")
-    redis_url = getattr(settings, "REDIS_URL", None)
+    def __init__(self):
+        super(RedisHealthCheck, self).__init__()
+        logger.debug("Checking for a redis_url in django settings...")
+        self.redis_url = getattr(settings, "REDIS_URL", None)
 
     def check_status(self):
         """Check Redis service by pinging the redis instance with a redis connection"""

--- a/health_check/contrib/redis/backends.py
+++ b/health_check/contrib/redis/backends.py
@@ -1,7 +1,7 @@
 import logging
 
 from django.conf import settings
-from redis import from_url, exceptions
+from redis import exceptions, from_url
 
 from health_check.backends import BaseHealthCheckBackend
 from health_check.exceptions import ServiceUnavailable

--- a/health_check/contrib/redis/backends.py
+++ b/health_check/contrib/redis/backends.py
@@ -1,7 +1,7 @@
 import logging
 
 from django.conf import settings
-from redis import from_url, exceptions
+from redis import exceptions, from_url
 
 from health_check.backends import BaseHealthCheckBackend
 from health_check.exceptions import ServiceUnavailable
@@ -24,7 +24,10 @@ class RedisHealthCheck(BaseHealthCheckBackend):
         try:
             # conn is used as a context to release opened resources later
             with from_url(redis_url) as conn:
+                print('conn', conn)
                 conn.ping()  # exceptions may be raised upon ping
+                print(conn.ping())
+                print('got here')
         except ConnectionRefusedError as e:
             self.add_error(ServiceUnavailable("Unable to connect to Redis: Connection was refused."), e)
         except exceptions.TimeoutError as e:

--- a/health_check/contrib/redis/backends.py
+++ b/health_check/contrib/redis/backends.py
@@ -1,7 +1,7 @@
 import logging
 
 from django.conf import settings
-from redis import exceptions, from_url
+from redis import from_url, exceptions
 
 from health_check.backends import BaseHealthCheckBackend
 from health_check.exceptions import ServiceUnavailable
@@ -12,18 +12,18 @@ logger = logging.getLogger(__name__)
 class RedisHealthCheck(BaseHealthCheckBackend):
     """Health check for Redis."""
 
+    logger.debug("Checking for a redis_url in django settings...")
+    redis_url = getattr(settings, "REDIS_URL", None)
+
     def check_status(self):
-        """Check Redis service by opening and closing a connection."""
-        logger.debug("Checking for a redis_url in django settings...")
+        """Check Redis service by pinging the redis instance with a redis connection"""
 
-        redis_url = getattr(settings, "REDIS_URL", None)
-
-        logger.debug("Got %s as the redis_url. Connecting to redis...", redis_url)
+        logger.debug("Got %s as the redis_url. Connecting to redis...", self.redis_url)
 
         logger.debug("Attempting to connect to redis...")
         try:
             # conn is used as a context to release opened resources later
-            with from_url(redis_url) as conn:
+            with from_url(self.redis_url) as conn:
                 conn.ping()  # exceptions may be raised upon ping
         except ConnectionRefusedError as e:
             self.add_error(ServiceUnavailable("Unable to connect to Redis: Connection was refused."), e)
@@ -34,4 +34,4 @@ class RedisHealthCheck(BaseHealthCheckBackend):
         except BaseException as e:
             self.add_error(ServiceUnavailable("Unknown error"), e)
         else:
-            logger.info("Connection established. Redis is healthy.")
+            logger.debug("Connection established. Redis is healthy.")

--- a/health_check/contrib/redis/backends.py
+++ b/health_check/contrib/redis/backends.py
@@ -13,23 +13,20 @@ class RedisHealthCheck(BaseHealthCheckBackend):
     """Health check for Redis."""
 
     def check_status(self):
-        """Check Redis service by opening and closing a broker channel."""
-        logger.debug("Checking for a broker_url on django settings...")
+        """Check Redis service by opening and closing a connection."""
+        logger.debug("Checking for a redis_url in django settings...")
 
-        broker_url = getattr(settings, "CELERY_BROKER_URL", None)
+        redis_url = getattr(settings, "REDIS_URL", None)
 
-        logger.debug("Got %s as the broker_url. Connecting to redis...", broker_url)
+        logger.debug("Got %s as the redis_url. Connecting to redis...", redis_url)
 
         logger.debug("Attempting to connect to redis...")
         try:
             # conn is used as a context to release opened resources later
-            with Connection(broker_url) as conn:
+            with Connection(redis_url) as conn:
                 conn.connect()  # exceptions may be raised upon calling connect
         except ConnectionRefusedError as e:
             self.add_error(ServiceUnavailable("Unable to connect to Redis: Connection was refused."), e)
-
-        # except AccessRefused as e:
-        #     self.add_error(ServiceUnavailable("Unable to connect to RabbitMQ: Authentication error."), e)
 
         except IOError as e:
             self.add_error(ServiceUnavailable("IOError"), e)

--- a/health_check/contrib/redis/backends.py
+++ b/health_check/contrib/redis/backends.py
@@ -1,8 +1,7 @@
 import logging
 
 from django.conf import settings
-from kombu import Connection
-from kombu.exceptions import TimeoutError, ConnectionLimitExceeded
+from kombu import Connection, exceptions
 
 from health_check.backends import BaseHealthCheckBackend
 from health_check.exceptions import ServiceUnavailable
@@ -28,9 +27,9 @@ class RedisHealthCheck(BaseHealthCheckBackend):
                 conn.connect()  # exceptions may be raised upon calling connect
         except ConnectionRefusedError as e:
             self.add_error(ServiceUnavailable("Unable to connect to Redis: Connection was refused."), e)
-        except TimeoutError as e:
+        except exceptions.TimeoutError as e:
             self.add_error(ServiceUnavailable("Unable to connect to Redis: Timeout."), e)
-        except ConnectionLimitExceeded as e:
+        except exceptions.ConnectionLimitExceeded as e:
             self.add_error(ServiceUnavailable("Unable to connect to Redis: "
                                               "Maximum number of simultaneous connections exceeded"), e)
         else:

--- a/health_check/contrib/redis/backends.py
+++ b/health_check/contrib/redis/backends.py
@@ -1,6 +1,5 @@
 import logging
 
-from amqp.exceptions import AccessRefused
 from django.conf import settings
 from kombu import Connection
 
@@ -10,27 +9,27 @@ from health_check.exceptions import ServiceUnavailable
 logger = logging.getLogger(__name__)
 
 
-class RabbitMQHealthCheck(BaseHealthCheckBackend):
-    """Health check for RabbitMQ."""
+class RedisHealthCheck(BaseHealthCheckBackend):
+    """Health check for Redis."""
 
     def check_status(self):
-        """Check RabbitMQ service by opening and closing a broker channel."""
+        """Check Redis service by opening and closing a broker channel."""
         logger.debug("Checking for a broker_url on django settings...")
 
-        broker_url = getattr(settings, "BROKER_URL", None)
+        broker_url = getattr(settings, "CELERY_BROKER_URL", None)
 
-        logger.debug("Got %s as the broker_url. Connecting to rabbit...", broker_url)
+        logger.debug("Got %s as the broker_url. Connecting to redis...", broker_url)
 
-        logger.debug("Attempting to connect to rabbit...")
+        logger.debug("Attempting to connect to redis...")
         try:
             # conn is used as a context to release opened resources later
             with Connection(broker_url) as conn:
                 conn.connect()  # exceptions may be raised upon calling connect
         except ConnectionRefusedError as e:
-            self.add_error(ServiceUnavailable("Unable to connect to RabbitMQ: Connection was refused."), e)
+            self.add_error(ServiceUnavailable("Unable to connect to Redis: Connection was refused."), e)
 
-        except AccessRefused as e:
-            self.add_error(ServiceUnavailable("Unable to connect to RabbitMQ: Authentication error."), e)
+        # except AccessRefused as e:
+        #     self.add_error(ServiceUnavailable("Unable to connect to RabbitMQ: Authentication error."), e)
 
         except IOError as e:
             self.add_error(ServiceUnavailable("IOError"), e)
@@ -38,4 +37,4 @@ class RabbitMQHealthCheck(BaseHealthCheckBackend):
         except BaseException as e:
             self.add_error(ServiceUnavailable("Unknown error"), e)
         else:
-            logger.debug("Connection established. RabbitMQ is healthy.")
+            logger.debug("Connection established. Redis is healthy.")

--- a/health_check/contrib/redis/backends.py
+++ b/health_check/contrib/redis/backends.py
@@ -18,8 +18,7 @@ class RedisHealthCheck(BaseHealthCheckBackend):
         self.redis_url = getattr(settings, "REDIS_URL", None)
 
     def check_status(self):
-        """Check Redis service by pinging the redis instance with a redis connection"""
-
+        """Check Redis service by pinging the redis instance with a redis connection."""
         logger.debug("Got %s as the redis_url. Connecting to redis...", self.redis_url)
 
         logger.debug("Attempting to connect to redis...")

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,3 +9,4 @@ pydocstyle
 pep8-naming
 pytest<4
 pytest-django
+redis==3.3.8

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,11 +32,12 @@ setup_requires =
     sphinx
     pytest-runner
 tests_require =
+    mock
     pytest
     pytest-cov
     pytest-django
     celery
-    mock
+    redis
 
 [bdist_wheel]
 universal = 1

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -1,0 +1,30 @@
+import mock
+
+from health_check.contrib.redis.backends import RedisHealthCheck
+
+
+class TestRabbitMQHealthCheck:
+    """Test Redis health check."""
+
+    @mock.patch("health_check.contrib.redis.backends.getattr")
+    @mock.patch("health_check.contrib.redis.backends.Connection")
+    def test_broker_refused_connection(self, mocked_connection, mocked_getattr):
+        """Test when the connection to Redis is refused."""
+        mocked_getattr.return_value = "broker_url"
+
+        conn_exception = ConnectionRefusedError("Refused connection")
+
+        # mock returns
+        mocked_conn = mock.MagicMock()
+        mocked_connection.return_value.__enter__.return_value = mocked_conn
+        mocked_conn.connect.side_effect = conn_exception
+
+        # instantiates the class
+        redis_healthchecker = RedisHealthCheck()
+
+        # invokes the method check_status()
+        redis_healthchecker.check_status()
+        assert len(redis_healthchecker.errors), 1
+
+        # mock assertions
+        mocked_connection.assert_called_once_with("celery_broker_url")

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -1,5 +1,5 @@
 import mock
-from kombu.exceptions import ConnectionLimitExceeded, TimeoutError
+from redis.exceptions import ConnectionError, TimeoutError
 
 from health_check.contrib.redis.backends import RedisHealthCheck
 
@@ -8,15 +8,14 @@ class TestRedisHealthCheck:
     """Test Redis health check."""
 
     @mock.patch("health_check.contrib.redis.backends.getattr")
-    @mock.patch("health_check.contrib.redis.backends.Connection")
+    @mock.patch("health_check.contrib.redis.backends.from_url", autospec=True)
     def test_redis_refused_connection(self, mocked_connection, mocked_getattr):
         """Test when the connection to Redis is refused."""
         mocked_getattr.return_value = "redis_url"
 
         # mock returns
-        mocked_conn = mock.MagicMock()
-        mocked_connection.return_value.__enter__.return_value = mocked_conn
-        mocked_conn.connect.side_effect = ConnectionRefusedError("Refused connection")
+        mocked_connection.return_value = mock.MagicMock()
+        mocked_connection.return_value.__enter__.side_effect = ConnectionRefusedError("Refused connection")
 
         # instantiates the class
         redis_healthchecker = RedisHealthCheck()
@@ -29,15 +28,14 @@ class TestRedisHealthCheck:
         mocked_connection.assert_called_once_with("redis_url")
 
     @mock.patch("health_check.contrib.redis.backends.getattr")
-    @mock.patch("health_check.contrib.redis.backends.Connection")
+    @mock.patch("health_check.contrib.redis.backends.from_url")
     def test_redis_timeout_error(self, mocked_connection, mocked_getattr):
         """Test Redis TimeoutError."""
         mocked_getattr.return_value = "redis_url"
 
         # mock returns
-        mocked_conn = mock.MagicMock()
-        mocked_connection.return_value.__enter__.return_value = mocked_conn
-        mocked_conn.connect.side_effect = TimeoutError("Timeout Error")
+        mocked_connection.return_value = mock.MagicMock()
+        mocked_connection.return_value.__enter__.side_effect = TimeoutError("Timeout Error")
 
         # instantiates the class
         redis_healthchecker = RedisHealthCheck()
@@ -50,15 +48,14 @@ class TestRedisHealthCheck:
         mocked_connection.assert_called_once_with("redis_url")
 
     @mock.patch("health_check.contrib.redis.backends.getattr")
-    @mock.patch("health_check.contrib.redis.backends.Connection")
+    @mock.patch("health_check.contrib.redis.backends.from_url")
     def test_redis_con_limit_exceeded(self, mocked_connection, mocked_getattr):
         """Test Connection Limit Exceeded error."""
         mocked_getattr.return_value = "redis_url"
 
         # mock returns
-        mocked_conn = mock.MagicMock()
-        mocked_connection.return_value.__enter__.return_value = mocked_conn
-        mocked_conn.connect.side_effect = ConnectionLimitExceeded("Connection limit exceeded")
+        mocked_connection.return_value = mock.MagicMock()
+        mocked_connection.return_value.__enter__.side_effect = ConnectionError("Connection Error")
 
         # instantiates the class
         redis_healthchecker = RedisHealthCheck()
@@ -69,3 +66,24 @@ class TestRedisHealthCheck:
 
         # mock assertions
         mocked_connection.assert_called_once_with("redis_url")
+
+    @mock.patch("health_check.contrib.redis.backends.getattr")
+    @mock.patch("health_check.contrib.redis.backends.from_url")
+    def test_redis_conn_ok(self, mocked_connection, mocked_getattr):
+        """Test everything is OK."""
+        mocked_getattr.return_value = "redis_url"
+
+        # mock returns
+        mocked_connection.return_value = mock.MagicMock()
+        mocked_connection.return_value.__enter__.side_effect = True
+
+        # instantiates the class
+        redis_healthchecker = RedisHealthCheck()
+
+        # invokes the method check_status()
+        redis_healthchecker.check_status()
+        assert len(redis_healthchecker.errors), 0
+
+        # mock assertions
+        mocked_connection.assert_called_once_with("redis_url")
+

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -10,7 +10,7 @@ class TestRabbitMQHealthCheck:
     @mock.patch("health_check.contrib.redis.backends.Connection")
     def test_broker_refused_connection(self, mocked_connection, mocked_getattr):
         """Test when the connection to Redis is refused."""
-        mocked_getattr.return_value = "broker_url"
+        mocked_getattr.return_value = "celery_broker_url"
 
         conn_exception = ConnectionRefusedError("Refused connection")
 

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -8,9 +8,9 @@ class TestRabbitMQHealthCheck:
 
     @mock.patch("health_check.contrib.redis.backends.getattr")
     @mock.patch("health_check.contrib.redis.backends.Connection")
-    def test_broker_refused_connection(self, mocked_connection, mocked_getattr):
+    def test_redis_refused_connection(self, mocked_connection, mocked_getattr):
         """Test when the connection to Redis is refused."""
-        mocked_getattr.return_value = "celery_broker_url"
+        mocked_getattr.return_value = "redis_url"
 
         conn_exception = ConnectionRefusedError("Refused connection")
 
@@ -27,4 +27,4 @@ class TestRabbitMQHealthCheck:
         assert len(redis_healthchecker.errors), 1
 
         # mock assertions
-        mocked_connection.assert_called_once_with("celery_broker_url")
+        mocked_connection.assert_called_once_with("redis_url")

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -1,9 +1,10 @@
 import mock
 
 from health_check.contrib.redis.backends import RedisHealthCheck
+from kombu.exceptions import TimeoutError, ConnectionLimitExceeded
 
 
-class TestRabbitMQHealthCheck:
+class TestRedisHealthCheck:
     """Test Redis health check."""
 
     @mock.patch("health_check.contrib.redis.backends.getattr")
@@ -12,12 +13,52 @@ class TestRabbitMQHealthCheck:
         """Test when the connection to Redis is refused."""
         mocked_getattr.return_value = "redis_url"
 
-        conn_exception = ConnectionRefusedError("Refused connection")
+        # mock returns
+        mocked_conn = mock.MagicMock()
+        mocked_connection.return_value.__enter__.return_value = mocked_conn
+        mocked_conn.connect.side_effect = ConnectionRefusedError("Refused connection")
+
+        # instantiates the class
+        redis_healthchecker = RedisHealthCheck()
+
+        # invokes the method check_status()
+        redis_healthchecker.check_status()
+        assert len(redis_healthchecker.errors), 1
+
+        # mock assertions
+        mocked_connection.assert_called_once_with("redis_url")
+
+    @mock.patch("health_check.contrib.redis.backends.getattr")
+    @mock.patch("health_check.contrib.redis.backends.Connection")
+    def test_redis_timeout_error(self, mocked_connection, mocked_getattr):
+        """Test Redis TimeoutError."""
+        mocked_getattr.return_value = "redis_url"
 
         # mock returns
         mocked_conn = mock.MagicMock()
         mocked_connection.return_value.__enter__.return_value = mocked_conn
-        mocked_conn.connect.side_effect = conn_exception
+        mocked_conn.connect.side_effect = TimeoutError("Timeout Error")
+
+        # instantiates the class
+        redis_healthchecker = RedisHealthCheck()
+
+        # invokes the method check_status()
+        redis_healthchecker.check_status()
+        assert len(redis_healthchecker.errors), 1
+
+        # mock assertions
+        mocked_connection.assert_called_once_with("redis_url")
+
+    @mock.patch("health_check.contrib.redis.backends.getattr")
+    @mock.patch("health_check.contrib.redis.backends.Connection")
+    def test_redis_con_limit_exceeded(self, mocked_connection, mocked_getattr):
+        """Test Connection Limit Exceeded error."""
+        mocked_getattr.return_value = "redis_url"
+
+        # mock returns
+        mocked_conn = mock.MagicMock()
+        mocked_connection.return_value.__enter__.return_value = mocked_conn
+        mocked_conn.connect.side_effect = ConnectionLimitExceeded("Connection limit exceeded")
 
         # instantiates the class
         redis_healthchecker = RedisHealthCheck()

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -1,7 +1,7 @@
 import mock
+from kombu.exceptions import ConnectionLimitExceeded, TimeoutError
 
 from health_check.contrib.redis.backends import RedisHealthCheck
-from kombu.exceptions import TimeoutError, ConnectionLimitExceeded
 
 
 class TestRedisHealthCheck:

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -25,7 +25,7 @@ class TestRedisHealthCheck:
         assert len(redis_healthchecker.errors), 1
 
         # mock assertions
-        mocked_connection.assert_called_once_with("redis_url")
+        mocked_connection.assert_called_once_with('redis://localhost/1')
 
     @mock.patch("health_check.contrib.redis.backends.getattr")
     @mock.patch("health_check.contrib.redis.backends.from_url")
@@ -45,7 +45,7 @@ class TestRedisHealthCheck:
         assert len(redis_healthchecker.errors), 1
 
         # mock assertions
-        mocked_connection.assert_called_once_with("redis_url")
+        mocked_connection.assert_called_once_with('redis://localhost/1')
 
     @mock.patch("health_check.contrib.redis.backends.getattr")
     @mock.patch("health_check.contrib.redis.backends.from_url")
@@ -65,7 +65,7 @@ class TestRedisHealthCheck:
         assert len(redis_healthchecker.errors), 1
 
         # mock assertions
-        mocked_connection.assert_called_once_with("redis_url")
+        mocked_connection.assert_called_once_with('redis://localhost/1')
 
     @mock.patch("health_check.contrib.redis.backends.getattr")
     @mock.patch("health_check.contrib.redis.backends.from_url")
@@ -85,4 +85,4 @@ class TestRedisHealthCheck:
         assert len(redis_healthchecker.errors), 0
 
         # mock assertions
-        mocked_connection.assert_called_once_with("redis_url")
+        mocked_connection.assert_called_once_with('redis://localhost/1')

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -86,4 +86,3 @@ class TestRedisHealthCheck:
 
         # mock assertions
         mocked_connection.assert_called_once_with("redis_url")
-


### PR DESCRIPTION
This adds support for a health check for Redis. 
More or less the same as the health check for RabbitMQ. 

It currently uses the `celery_broker_url` from Django settings. This could be changed to `broker_url` that RabbitMQ uses, if wanted. 