### PR TITLE
Added support for redis 2.10.6 check

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -110,12 +110,10 @@ on django.conf.settings with the required format to connect to your redis server
 To use the Celery healthcheck, if checking just for default celery queue, no need to do any changes.
 
 But if you want to check for some more queues along with default ones, please make sure that there
-are 2 variables named ``USE_DEFAULT_QUEUE`` and ``CELERY_QUEUES`` on django.conf.settings and set the value of ``USE_DEFAULT_QUEUE`` to False and ``CELERY_QUEUES`` to ['A', 'B'] where 'A' and 'B' are celery queues.
-please make sure that there is a variable named ``REDIS_HOST``
+is a variables named ``CELERY_QUEUES`` on django.conf.settings and set its value to ['A', 'B'] where 'A' and 'B' are celery queues.
 
 .. code::
 
-    USE_DEFAULT_QUEUE = False
     CELERY_QUEUES = ['A', 'B']
 
 Setting up monitoring

--- a/README.rst
+++ b/README.rst
@@ -100,12 +100,23 @@ on django.conf.settings with the required format to connect to your rabbit serve
 
     BROKER_URL = amqp://myuser:mypassword@localhost:5672/myvhost
 
-To use the Redis healthcheck, please make sure that there is a variable named ``REDIS_URL``
-on django.conf.settings with the required format to connect to your redis server. For example:
+To use the Redis healthcheck, please make sure that there is a variable named ``REDIS_HOST``
+on django.conf.settings with the required format to connect to your redis server. If your redis is running on some port other than 6379, make sure to add a variable ``REDIS_PORT`` with its value set to the the port on which redis server is running. For example:
 
 .. code::
 
-    REDIS_URL = redis://localhost:6370
+    REDIS_HOST = localhost
+
+To use the Celery healthcheck, if checking just for default celery queue, no need to do any changes.
+
+But if you want to check for some more queues along with default ones, please make sure that there
+are 2 variables named ``USE_DEFAULT_QUEUE`` and ``CELERY_QUEUES`` on django.conf.settings and set the value of ``USE_DEFAULT_QUEUE`` to False and ``CELERY_QUEUES`` to ['A', 'B'] where 'A' and 'B' are celery queues.
+please make sure that there is a variable named ``REDIS_HOST``
+
+.. code::
+
+    USE_DEFAULT_QUEUE = False
+    CELERY_QUEUES = ['A', 'B']
 
 Setting up monitoring
 ---------------------

--- a/health_check/contrib/celery/apps.py
+++ b/health_check/contrib/celery/apps.py
@@ -13,20 +13,14 @@ class HealthCheckConfig(AppConfig):
 
         # To check if we want to check just for default celery queue which is
         # 'celery', you don't need to define anything, else
-        # USE_DEFAULT_QUEUE = True and CELERY_QUEUES = [queues used in your project]
-        use_default_queue = getattr(settings, 'USE_DEFAULT_QUEUE', True)
+        # CELERY_QUEUES = [queues used in your project]
+        queues = getattr(settings, 'CELERY_QUEUES', [])
 
-        if use_default_queue:
-            for queue in current_app.amqp.queues:
-                celery_class_name = 'CeleryHealthCheck - ' + queue.title()
+        if not queues:
+            queues = [queue for queue in current_app.amqp.queues]
 
-                celery_class = type(celery_class_name, (CeleryHealthCheck,), {'queue': queue})
-                plugin_dir.register(celery_class)
+        for queue in queues:
+            celery_class_name = 'CeleryHealthCheck - ' + queue.title()
 
-        else:
-            queues = getattr(settings, 'CELERY_QUEUES', [])
-            for queue in queues:
-                celery_class_name = 'CeleryHealthCheck - ' + queue.title()
-
-                celery_class = type(celery_class_name, (CeleryHealthCheck,), {'queue': queue})
-                plugin_dir.register(celery_class)
+            celery_class = type(celery_class_name, (CeleryHealthCheck,), {'queue': queue})
+            plugin_dir.register(celery_class)

--- a/health_check/contrib/celery/apps.py
+++ b/health_check/contrib/celery/apps.py
@@ -1,5 +1,6 @@
 from celery import current_app
 from django.apps import AppConfig
+from django.conf import settings
 
 from health_check.plugins import plugin_dir
 
@@ -10,8 +11,22 @@ class HealthCheckConfig(AppConfig):
     def ready(self):
         from .backends import CeleryHealthCheck
 
-        for queue in current_app.amqp.queues:
-            celery_class_name = 'CeleryHealthCheck' + queue.title()
+        # To check if we want to check just for default celery queue which is
+        # 'celery', you don't need to define anything, else
+        # USE_DEFAULT_QUEUE = True and CELERY_QUEUES = [queues used in your project]
+        use_default_queue = getattr(settings, 'USE_DEFAULT_QUEUE', True)
 
-            celery_class = type(celery_class_name, (CeleryHealthCheck,), {'queue': queue})
-            plugin_dir.register(celery_class)
+        if use_default_queue:
+            for queue in current_app.amqp.queues:
+                celery_class_name = 'CeleryHealthCheck - ' + queue.title()
+
+                celery_class = type(celery_class_name, (CeleryHealthCheck,), {'queue': queue})
+                plugin_dir.register(celery_class)
+
+        else:
+            queues = getattr(settings, 'CELERY_QUEUES', [])
+            for queue in queues:
+                celery_class_name = 'CeleryHealthCheck - ' + queue.title()
+
+                celery_class = type(celery_class_name, (CeleryHealthCheck,), {'queue': queue})
+                plugin_dir.register(celery_class)

--- a/health_check/contrib/redis/backends.py
+++ b/health_check/contrib/redis/backends.py
@@ -1,7 +1,7 @@
 import logging
 
 from django.conf import settings
-from redis import exceptions, from_url
+from redis import exceptions, Redis
 
 from health_check.backends import BaseHealthCheckBackend
 from health_check.exceptions import ServiceUnavailable
@@ -12,17 +12,22 @@ logger = logging.getLogger(__name__)
 class RedisHealthCheck(BaseHealthCheckBackend):
     """Health check for Redis."""
 
-    redis_url = getattr(settings, "REDIS_URL", 'redis://localhost/1')
+    redis_host = getattr(settings, "REDIS_HOST", 'localhost')
+    redis_port = getattr(settings, "REDIS_PORT", '6379')
 
     def check_status(self):
         """Check Redis service by pinging the redis instance with a redis connection."""
-        logger.debug("Got %s as the redis_url. Connecting to redis...", self.redis_url)
+        logger.debug("Got %s as the redis_url. Connecting to redis...", self.redis_host)
 
         logger.debug("Attempting to connect to redis...")
         try:
-            # conn is used as a context to release opened resources later
-            with from_url(self.redis_url) as conn:
-                conn.ping()  # exceptions may be raised upon ping
+            # Keeping the timeout 2 sec, so that connection closes after health check
+            conn = Redis(
+                host=self.redis_host,
+                port=self.redis_port,
+                socket_connect_timeout=2
+            )
+            conn.ping()  # exceptions may be raised upon ping
         except ConnectionRefusedError as e:
             self.add_error(ServiceUnavailable("Unable to connect to Redis: Connection was refused."), e)
         except exceptions.TimeoutError as e:


### PR DESCRIPTION
Currently, the code breaks for redis 2.10.6, but we have to use that version of redis only since its the one supported by celery. So I just changed the way to check the status of redis.
Also, for celery check, there is a case where we don't have the celery queues defined in celery app, in that case, we cannot check the status of those queues, so just added a way to check the status of queues using a settings variable which contains the list of queues used in your project. 