### PR TITLE
Fix typo in health_check command documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -283,7 +283,7 @@ This should yield the following output:
     DatabaseHealthCheck      ... working
     CustomHealthCheck        ... unavailable: Something went wrong!
 
-Similar to the http version, a critical error will case the command to quit with the exit code `1`.
+Similar to the http version, a critical error will cause the command to quit with the exit code `1`.
 
 
 Other resources


### PR DESCRIPTION
Causing a command to quit has nothing to do with capitalization, boxes or conditionals, so it should be written with a u between a and s ;)