### PR TITLE
Improve GitHub Actions PyPI release trigger (refs #250)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,20 +1,22 @@
-name: Release
+name: PyPI release
 
-on: [release]
+on:
+  release:
+    types: [released]
 
 jobs:
-
-  PyPi:
+  PyPI:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
-    - name: Install Python dependencies
-      run: python -m pip install --upgrade pip setuptools wheel twine
-    - name: Build dist packages
-      run: python setup.py sdist bdist_wheel
-    - name: Upload packages
-      run: python -m twine upload dist/*
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+
+      - name: Install Python dependencies
+        run: python -m pip install --upgrade pip setuptools wheel twine
+      - name: Build dist packages
+        run: python setup.py sdist bdist_wheel
+      - name: Upload packages
+        run: python -m twine upload dist/*
+        env:
+          TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,8 @@
-name: PyPI release
+name: Release
 
 on:
   release:
-    types: [released]
+    types: [published]
 
 jobs:
   PyPI:
@@ -18,5 +18,5 @@ jobs:
       - name: Upload packages
         run: python -m twine upload dist/*
         env:
-          TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
+          TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}


### PR DESCRIPTION
Hey @codingjoe!

Thanks for actively maintaining this and plenty of other packages, you are the champion! :)
I was replacing Travis CI with GitHub actions in one of my packages (https://github.com/amureki/statuscheck) and was inspired by your code here in #250.

However, I noticed a couple of things that were not correct from my perspective:

- release job was triggered three times (fixed by [specifying exact action type "published"](https://help.github.com/en/actions/reference/events-that-trigger-workflows#release-event-release))
~~- TWINE_USERNAME variable was coming from `__token__` - not sure I follow, how this works, but I changed it to `secrets.TWINE_USERNAME`~~
- (other) I put a couple of naming suggestions, feel free to disregard