### PR TITLE
Clean results task Health Check

### DIFF
--- a/health_check/contrib/celery/backends.py
+++ b/health_check/contrib/celery/backends.py
@@ -21,6 +21,7 @@ class CeleryHealthCheck(BaseHealthCheckBackend):
             result.get(timeout=timeout)
             if result.result != 8:
                 self.add_error(ServiceReturnedUnexpectedResult("Celery returned wrong result"))
+            add.forget()
         except IOError as e:
             self.add_error(ServiceUnavailable("IOError"), e)
         except NotImplementedError as e:


### PR DESCRIPTION
It is necessary a elimination of the task after its verification to avoid the accumulation of results in views such as flower or saturating the backend