### PR TITLE
make MainView more extensible

### DIFF
--- a/health_check/templates/health_check/index.html
+++ b/health_check/templates/health_check/index.html
@@ -1,32 +1,40 @@
 <html>
 <head>
-  <title>System status</title>
+  <title>
+    {% block title %}
+      System status
+    {% endblock title %}
+  </title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="https://www.w3schools.com/w3css/4/w3.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
+  {% block extra_head %}
+  {% endblock extra_head %}
 </head>
 <body class="w3-content">
-<h1 class="w3-center">System status</h1>
-<table class="w3-table w3-striped w3-white">
-  <tr class="w3-blue">
-    <th colspan="2">Service</th>
-    <th>Status</th>
-    <th class="w3-hide-small w3-hide-medium w3-right">Time Taken</th>
-  </tr>
-  {% for plugin in plugins %}
-  <tr>
-    <td class="w3-center" style="width: 50px">
-      {% if plugin.status %}
-      <i class="w3-text-green fa fa-check" aria-hidden="true"></i>
-      {% else %}
-      <i class="w3-text-red fa fa-close" aria-hidden="true"></i>
-      {% endif %}
-    </td>
-    <td>{{ plugin.identifier }}</td>
-    <td>{{ plugin.pretty_status }}</td>
-    <td class="w3-hide-small w3-hide-medium w3-right">{{ plugin.time_taken|floatformat:4 }} seconds</td>
-  </tr>
-  {% endfor %}
-</table>
+  {% block content %}
+    <h1 class="w3-center">System status</h1>
+    <table class="w3-table w3-striped w3-white">
+      <tr class="w3-blue">
+        <th colspan="2">Service</th>
+        <th>Status</th>
+        <th class="w3-hide-small w3-hide-medium w3-right">Time Taken</th>
+      </tr>
+      {% for plugin in plugins %}
+        <tr>
+          <td class="w3-center" style="width: 50px">
+            {% if plugin.status %}
+              <i class="w3-text-green fa fa-check" aria-hidden="true"></i>
+            {% else %}
+              <i class="w3-text-red fa fa-close" aria-hidden="true"></i>
+            {% endif %}
+          </td>
+          <td>{{ plugin.identifier }}</td>
+          <td>{{ plugin.pretty_status }}</td>
+          <td class="w3-hide-small w3-hide-medium w3-right">{{ plugin.time_taken|floatformat:4 }} seconds</td>
+        </tr>
+      {% endfor %}
+    </table>
+  {% endblock content %}
 </body>
 </html>

--- a/health_check/templates/health_check/index.html
+++ b/health_check/templates/health_check/index.html
@@ -1,15 +1,10 @@
 <html>
 <head>
-  <title>
-    {% block title %}
-      System status
-    {% endblock title %}
-  </title>
+  <title>{% block title %}System status{% endblock title %}</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="https://www.w3schools.com/w3css/4/w3.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
-  {% block extra_head %}
-  {% endblock extra_head %}
+  {% block extra_head %}{% endblock extra_head %}
 </head>
 <body class="w3-content">
   {% block content %}

--- a/health_check/views.py
+++ b/health_check/views.py
@@ -92,15 +92,20 @@ class MainView(CheckMixin, TemplateView):
         accept_header = request.META.get('HTTP_ACCEPT', '*/*')
         for media in MediaType.parse_header(accept_header):
             if media.mime_type in ('text/html', 'application/xhtml+xml', 'text/*', '*/*'):
-                context = {'plugins': self.plugins, 'status_code': status_code}
+                context = self.get_context_data(**kwargs)
                 return self.render_to_response(context, status=status_code)
             elif media.mime_type in ('application/json', 'application/*'):
                 return self.render_to_response_json(self.plugins, status_code)
         return HttpResponse(
             'Not Acceptable: Supported content types: text/html, application/json',
             status=406,
-            content_type='text/plain'
+            content_type='text/plain',
         )
+
+    def get_context_data(self, **kwargs):
+        context_data = super().get_context_data(**kwargs)
+        context_data['plugins'] = self.plugins
+        return context_data
 
     def render_to_response_json(self, plugins, status):
         return JsonResponse(

--- a/health_check/views.py
+++ b/health_check/views.py
@@ -103,9 +103,7 @@ class MainView(CheckMixin, TemplateView):
         )
 
     def get_context_data(self, **kwargs):
-        context_data = super().get_context_data(**kwargs)
-        context_data['plugins'] = self.plugins
-        return context_data
+        return {**super().get_context_data(**kwargs), "plugins": self.plugins}
 
     def render_to_response_json(self, plugins, status):
         return JsonResponse(


### PR DESCRIPTION
Hi,

first of all, big thanks for maintaining great project!

Recently I had some requirements to adjust some content of health checks view and it was really hard to do without totally overriding template and view.
Currently it's impossible to pass any additional values as context to `render_to_response` and extend `healt_check/index.html` template.

In this PR, I refactored `MainView` a bit, so it will be easier to extend `healt_check/index.html` template by:

+ `tittle`, `extra_head` and `content` blocks
+ `get_context_data`, which  is now used to get context passed to `render_to_response` (like it is done in `TemplateView.get` implementation)