### PR TITLE
fix and refactor CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,30 +1,34 @@
+---
 language: python
 cache: pip
 dist: xenial
 python:
-- '3.6'
-- '3.7'
+  - '3.6'
+  - '3.7'
+  - '3.8'
 env:
   matrix:
-  - TOXENV=docs
-  - DJANGO=111
-  - DJANGO=22
-  - DJANGO=master
+    - TOXENV=docs
+    - DJANGO=111
+    - DJANGO=22
+    - DJANGO=30
+    - DJANGO=31
+    - DJANGO=master
 services:
   - redis
 matrix:
   fast_finish: true
   allow_failures:
-  - env: DJANGO=master
+    - env: DJANGO=master
 install:
-- pip install --upgrade codecov tox
+  - pip install --upgrade codecov tox
 before_script:
-- |
-  if [[ -z $TOXENV ]]; then
-    export TOXENV=py$(echo $TRAVIS_PYTHON_VERSION | sed -e 's/\.//g')-dj$DJANGO
-  fi
-- echo $TOXENV
+  - |
+    if [[ -z $TOXENV ]]; then
+      export TOXENV=py$(echo $TRAVIS_PYTHON_VERSION | sed -e 's/\.//g')-dj$DJANGO
+    fi
+  - echo $TOXENV
 script:
-- tox -e $TOXENV
+  - tox -e $TOXENV
 after_success:
-- codecov
+  - codecov

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include LICENSE
-recursive-include health_check
-prune tests docs
+recursive-include health_check *
+prune tests
+prune docs

--- a/setup.cfg
+++ b/setup.cfg
@@ -94,7 +94,7 @@ build_dir = docs/_build
 warning-is-error = 1
 
 [tox:tox]
-envlist = py{36,37}-dj{111,20,master},qa
+envlist = py{36,37,38}-dj{111,22,30,31,master},qa
 
 [testenv]
 setenv=
@@ -102,6 +102,8 @@ setenv=
 deps=
     dj111: https://github.com/django/django/archive/stable/1.11.x.tar.gz#egg=django
     dj22: https://github.com/django/django/archive/stable/2.2.x.tar.gz#egg=django
+    dj30: https://github.com/django/django/archive/stable/3.0.x.tar.gz#egg=django
+    dj31: https://github.com/django/django/archive/stable/3.1.x.tar.gz#egg=django
     djmaster: https://github.com/django/django/archive/master.tar.gz#egg=django
 commands=
     python setup.py test

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,7 +53,13 @@ test = pytest
 [tool:pytest]
 norecursedirs=venv env .eggs
 DJANGO_SETTINGS_MODULE=tests.testapp.settings
-addopts = --tb=short -rxs
+addopts =
+    --tb=short
+    -rxs
+    --cov=.
+    --cov-config=setup.cfg
+    --cov-report=xml
+    --cov-report=term
 
 [flake8]
 max-line-length = 119
@@ -68,16 +74,19 @@ match-dir = (?!tests|env|.eggs|\.).*
 
 [coverage:run]
 source = .
+branch = True
 omit =
   */migrations/*
   */tests/*
   */test_*.py
-  .tox
-  .eggs
+  .tox/*
+  .eggs/*
 
 [coverage:report]
 ignore_errors = True
 show_missing = True
+skip_covered = True
+sort = Cover
 
 [build_sphinx]
 source_dir = docs


### PR DESCRIPTION
This PR resolves some issues I have spotted during working on #259 :

+ generates coverage report so it can be consumed by `codecov` in CI (travis)
+ adjust some coverage settings and print coverage report in terminal
+ add django 3.0.x, django 3.1.x and python 3.8 to build matrix
+ refactor `.travis.yml` formatting and syntax