### PR TITLE
Added more detail for celery task timeouts

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -287,32 +287,6 @@ This should yield the following output:
 
 Similar to the http version, a critical error will cause the command to quit with the exit code `1`.
 
-
-Advanced Configuration
-----------------------
-Using `django.settings` you may exert more fine-grained control over the behavior of `django-health-check`.
-
-.. list-table:: Additional Settings
-   :widths: 25 10 10 55
-   :header-rows: 1
-
-   * - Name
-     - Type
-     - Default
-     - Description
-   * - `HEALTHCHECK_CELERY_TIMEOUT`
-     - Number
-     - 3
-     - Base timeout, in seconds, for a celery task to complete. Depricated.
-   * - `HEALTHCHECK_CELERY_QUEUE_TIMEOUT`
-     - Number
-     - `HEALTHCHECK_CELERY_TIMEOUT` (3)
-     - Overrides `HEALTHCHECK_CELERY_TIMEOUT`, specifying the maximum amount of time a task may spend in the queue before being automatically revoked with a `TaskRevokedError`.
-   * - `HEALTHCHECK_CELERY_RESULT_TIMEOUT`
-     - Number
-     - `HEALTHCHECK_CELERY_TIMEOUT` (3)
-     - Overrides `HEALTHCHECK_CELERY_TIMEOUT`, specifying the maximum total time for a task to complete and return a result.
-
 Other resources
 ---------------
 

--- a/README.rst
+++ b/README.rst
@@ -287,6 +287,7 @@ This should yield the following output:
 
 Similar to the http version, a critical error will cause the command to quit with the exit code `1`.
 
+
 Other resources
 ---------------
 

--- a/README.rst
+++ b/README.rst
@@ -295,17 +295,17 @@ Advanced Configuration
 Using `django.settings` you may exert more fine-grained control over the behavior of `django-health-check`.
 
 .. list-table:: Additional Settings
-   :widths 25 10 10 55
-   :header-rows 1
+   :widths: 25 10 10 55
+   :header-rows: 1
 
-   * - Variable Name
+   * - Name
      - Type
      - Default
      - Description
    * - `HEALTHCHECK_CELERY_TIMEOUT`
      - Number
      - 3
-     - Base timeout, in seconds, for a celery task to complete. Depricated in favor of `HEALTHCHECK_CELERY_RESULT_TIMEOUT`
+     - Base timeout, in seconds, for a celery task to complete. Depricated.
    * - `HEALTHCHECK_CELERY_QUEUE_TIMEOUT`
      - Number
      - `HEALTHCHECK_CELERY_TIMEOUT` (3)

--- a/README.rst
+++ b/README.rst
@@ -290,6 +290,31 @@ This should yield the following output:
 Similar to the http version, a critical error will cause the command to quit with the exit code `1`.
 
 
+Advanced Configuration
+--------------
+Using `django.settings` you may exert more fine-grained control over the behavior of `django-health-check`.
+
+.. list-table:: Additional Settings
+   :widths 25 10 10 55
+   :header-rows 1
+
+   * - Variable Name
+     - Type
+     - Default
+     - Description
+   * - `HEALTHCHECK_CELERY_TIMEOUT`
+     - Number
+     - 3
+     - Base timeout, in seconds, for a celery task to complete. Depricated in favor of `HEALTHCHECK_CELERY_RESULT_TIMEOUT`
+   * - `HEALTHCHECK_CELERY_QUEUE_TIMEOUT`
+     - Number
+     - `HEALTHCHECK_CELERY_TIMEOUT` (3)
+     - Overrides `HEALTHCHECK_CELERY_TIMEOUT`, specifying the maximum amount of time a task may spend in the queue before being automatically revoked with a `TaskRevokedError`.
+   * - `HEALTHCHECK_CELERY_RESULT_TIMEOUT`
+     - Number
+     - `HEALTHCHECK_CELERY_TIMEOUT` (3)
+     - Overrides `HEALTHCHECK_CELERY_TIMEOUT`, specifying the maximum total time for a task to complete and return a result.
+
 Other resources
 ---------------
 

--- a/README.rst
+++ b/README.rst
@@ -291,7 +291,7 @@ Similar to the http version, a critical error will cause the command to quit wit
 
 
 Advanced Configuration
---------------
+----------------------
 Using `django.settings` you may exert more fine-grained control over the behavior of `django-health-check`.
 
 .. list-table:: Additional Settings

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -82,15 +82,11 @@ Using `django.settings` you may exert more fine-grained control over the behavio
      - Type
      - Default
      - Description
-   * - `HEALTHCHECK_CELERY_TIMEOUT`
-     - Number
-     - 3
-     - Base timeout, in seconds, for a celery task to complete. Depricated.
    * - `HEALTHCHECK_CELERY_QUEUE_TIMEOUT`
      - Number
-     - `HEALTHCHECK_CELERY_TIMEOUT` (3)
-     - Overrides `HEALTHCHECK_CELERY_TIMEOUT`, specifying the maximum amount of time a task may spend in the queue before being automatically revoked with a `TaskRevokedError`.
+     - 3
+     - Specifies the maximum amount of time a task may spend in the queue before being automatically revoked with a `TaskRevokedError`.
    * - `HEALTHCHECK_CELERY_RESULT_TIMEOUT`
      - Number
-     - `HEALTHCHECK_CELERY_TIMEOUT` (3)
-     - Overrides `HEALTHCHECK_CELERY_TIMEOUT`, specifying the maximum total time for a task to complete and return a result.
+     - 3
+     - Specifies the maximum total time for a task to complete and return a result, including queue time.

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -69,3 +69,28 @@ exceeds 90% or available memory drops below 100 MB.
 
    Specify the desired memory utilization threshold, in megabytes. When available
    memory falls below the specified value, a warning will be reported.
+
+Celery Health Check
+----------------------
+Using `django.settings` you may exert more fine-grained control over the behavior of the celery health check
+
+.. list-table:: Additional Settings
+   :widths: 25 10 10 55
+   :header-rows: 1
+
+   * - Name
+     - Type
+     - Default
+     - Description
+   * - `HEALTHCHECK_CELERY_TIMEOUT`
+     - Number
+     - 3
+     - Base timeout, in seconds, for a celery task to complete. Depricated.
+   * - `HEALTHCHECK_CELERY_QUEUE_TIMEOUT`
+     - Number
+     - `HEALTHCHECK_CELERY_TIMEOUT` (3)
+     - Overrides `HEALTHCHECK_CELERY_TIMEOUT`, specifying the maximum amount of time a task may spend in the queue before being automatically revoked with a `TaskRevokedError`.
+   * - `HEALTHCHECK_CELERY_RESULT_TIMEOUT`
+     - Number
+     - `HEALTHCHECK_CELERY_TIMEOUT` (3)
+     - Overrides `HEALTHCHECK_CELERY_TIMEOUT`, specifying the maximum total time for a task to complete and return a result.

--- a/health_check/contrib/celery/apps.py
+++ b/health_check/contrib/celery/apps.py
@@ -15,7 +15,8 @@ class HealthCheckConfig(AppConfig):
         if hasattr(settings, "HEALTHCHECK_CELERY_TIMEOUT"):
             logger = logging.getLogger('health-check')
             logger.warn("HEALTHCHECK_CELERY_TIMEOUT is depricated and may be removed in the "
-                        "future. Please use HEALTHCHECK_CELERY_RESULT_TIMEOUT instead.")
+                        "future. Please use HEALTHCHECK_CELERY_RESULT_TIMEOUT and "
+                        "HEALTHCHECK_CELERY_QUEUE_TIMEOUT instead.")
 
         for queue in current_app.amqp.queues:
             celery_class_name = 'CeleryHealthCheck' + queue.title()

--- a/health_check/contrib/celery/apps.py
+++ b/health_check/contrib/celery/apps.py
@@ -1,5 +1,8 @@
 from celery import current_app
 from django.apps import AppConfig
+from django.conf import settings
+import logging
+
 
 from health_check.plugins import plugin_dir
 
@@ -9,6 +12,10 @@ class HealthCheckConfig(AppConfig):
 
     def ready(self):
         from .backends import CeleryHealthCheck
+        if hasattr(settings, "HEALTHCHECK_CELERY_TIMEOUT"):
+            logger = logging.getLogger('health-check')
+            logger.warn("HEALTHCHECK_CELERY_TIMEOUT is depricated and may be removed in the "
+                        "future. Please use HEALTHCHECK_CELERY_RESULT_TIMEOUT instead.")
 
         for queue in current_app.amqp.queues:
             celery_class_name = 'CeleryHealthCheck' + queue.title()

--- a/health_check/contrib/celery/apps.py
+++ b/health_check/contrib/celery/apps.py
@@ -1,7 +1,7 @@
 from celery import current_app
 from django.apps import AppConfig
 from django.conf import settings
-import logging
+import warnings
 
 
 from health_check.plugins import plugin_dir
@@ -13,10 +13,9 @@ class HealthCheckConfig(AppConfig):
     def ready(self):
         from .backends import CeleryHealthCheck
         if hasattr(settings, "HEALTHCHECK_CELERY_TIMEOUT"):
-            logger = logging.getLogger('health-check')
-            logger.warn("HEALTHCHECK_CELERY_TIMEOUT is depricated and may be removed in the "
+            warnings.warn("HEALTHCHECK_CELERY_TIMEOUT is depricated and may be removed in the "
                         "future. Please use HEALTHCHECK_CELERY_RESULT_TIMEOUT and "
-                        "HEALTHCHECK_CELERY_QUEUE_TIMEOUT instead.")
+                        "HEALTHCHECK_CELERY_QUEUE_TIMEOUT instead.", DeprecationWarning)
 
         for queue in current_app.amqp.queues:
             celery_class_name = 'CeleryHealthCheck' + queue.title()

--- a/health_check/contrib/celery/backends.py
+++ b/health_check/contrib/celery/backends.py
@@ -6,19 +6,22 @@ from health_check.exceptions import (
 )
 
 from .tasks import add
+from celery.exceptions import TaskRevokedError, TimeoutError
 
 
 class CeleryHealthCheck(BaseHealthCheckBackend):
     def check_status(self):
         timeout = getattr(settings, 'HEALTHCHECK_CELERY_TIMEOUT', 3)
+        result_timeout = getattr(settings, 'HEALTHCHECK_CELERY_RESULT_TIMEOUT', timeout)
+        queue_timeout = getattr(settings, 'HEALTHCHECK_CELERY_QUEUE_TIMEOUT', timeout)
 
         try:
             result = add.apply_async(
                 args=[4, 4],
-                expires=timeout,
+                expires=queue_timeout,
                 queue=self.queue
             )
-            result.get(timeout=timeout)
+            result.get(timeout=result_timeout)
             if result.result != 8:
                 self.add_error(ServiceReturnedUnexpectedResult("Celery returned wrong result"))
             add.forget()
@@ -26,5 +29,9 @@ class CeleryHealthCheck(BaseHealthCheckBackend):
             self.add_error(ServiceUnavailable("IOError"), e)
         except NotImplementedError as e:
             self.add_error(ServiceUnavailable("NotImplementedError: Make sure CELERY_RESULT_BACKEND is set"), e)
+        except TaskRevokedError as e:
+            self.add_error(ServiceUnavailable("TaskRevokedError: The task was revoked, likely because it spent too long in the queue"), e)
+        except TimeoutError as e:
+            self.add_error(ServiceUnavailable("TimeoutError: The task took too long to return a result"), e)
         except BaseException as e:
             self.add_error(ServiceUnavailable("Unknown error"), e)

--- a/health_check/contrib/celery/backends.py
+++ b/health_check/contrib/celery/backends.py
@@ -30,7 +30,8 @@ class CeleryHealthCheck(BaseHealthCheckBackend):
         except NotImplementedError as e:
             self.add_error(ServiceUnavailable("NotImplementedError: Make sure CELERY_RESULT_BACKEND is set"), e)
         except TaskRevokedError as e:
-            self.add_error(ServiceUnavailable("TaskRevokedError: The task was revoked, likely because it spent too long in the queue"), e)
+            self.add_error(ServiceUnavailable("TaskRevokedError: The task was revoked, likely because it spent "
+                                              "too long in the queue"), e)
         except TimeoutError as e:
             self.add_error(ServiceUnavailable("TimeoutError: The task took too long to return a result"), e)
         except BaseException as e:


### PR DESCRIPTION
Hello. I created this pull request because we were having difficulties where the celery health check backend was failing but it was challenging to inspect why. To address this, I have added:

- More detailed message for cases where a task takes too long to start (waits too long in queue)
- More detailed message for cases where a task takes too long to return a result (waits to long in queue or takes too long to recieve result... basically, the original timeout behavior)
- Added settings. Both default to the value of the original HEALTHCHECK_CELERY_TIMEOUT (which defaults to 3), because not all use cases will want split control, and to maintain backwards compatibility. 
  - HEALTHCHECK_CELERY_QUEUE_TIMEOUT, which sets the maximum time for a task to wait in queue
  - HEALTHCHECK_CELERY_RESULT_TIMEOUT, which sets the maximum time for a task to return a result (queue + execution + response time)

I decided to add the two new settings because my particular celery backend doesn't report tasks that expire as failures and eventually discards them entirely, which makes it really challenging to identify *why* the tasks are expiring in the queue. With the finer control, we'll be able to extend the max queue time without impacting the acceptable performance criteria (i.e., while making sure health checks still fail if jobs take too long)