### PR TITLE
make cache health check aware of all cache backends

### DIFF
--- a/health_check/cache/apps.py
+++ b/health_check/cache/apps.py
@@ -1,4 +1,5 @@
 from django.apps import AppConfig
+from django.conf import settings
 
 from health_check.plugins import plugin_dir
 
@@ -8,4 +9,6 @@ class HealthCheckConfig(AppConfig):
 
     def ready(self):
         from .backends import CacheBackend
-        plugin_dir.register(CacheBackend)
+
+        for backend in settings.CACHES:
+            plugin_dir.register(CacheBackend, backend=backend)

--- a/health_check/cache/backends.py
+++ b/health_check/cache/backends.py
@@ -7,9 +7,9 @@ from health_check.exceptions import (
 
 
 class CacheBackend(BaseHealthCheckBackend):
-    def __init__(self, backend=''):
+    def __init__(self, backend='default'):
         super().__init__()
-        self.backend = backend or 'default'
+        self.backend = backend
 
     def identifier(self):
         return f"Cache backend: {self.backend}"

--- a/health_check/cache/backends.py
+++ b/health_check/cache/backends.py
@@ -1,4 +1,4 @@
-from django.core.cache import CacheKeyWarning, cache
+from django.core.cache import CacheKeyWarning, caches
 
 from health_check.backends import BaseHealthCheckBackend
 from health_check.exceptions import (
@@ -7,7 +7,16 @@ from health_check.exceptions import (
 
 
 class CacheBackend(BaseHealthCheckBackend):
+    def __init__(self, backend=''):
+        super().__init__()
+        self.backend = backend or 'default'
+
+    def identifier(self):
+        return "Cache backend: %s" % self.backend
+
     def check_status(self):
+        cache = caches[self.backend]
+
         try:
             cache.set('djangohealtcheck_test', 'itworks', 1)
             if not cache.get("djangohealtcheck_test") == "itworks":

--- a/health_check/cache/backends.py
+++ b/health_check/cache/backends.py
@@ -12,7 +12,7 @@ class CacheBackend(BaseHealthCheckBackend):
         self.backend = backend or 'default'
 
     def identifier(self):
-        return "Cache backend: %s" % self.backend
+        return f"Cache backend: {self.backend}"
 
     def check_status(self):
         cache = caches[self.backend]

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -45,14 +45,28 @@ class HealthCheckCacheTests(TestCase):
     Ensures check_status returns/raises the expected result when the cache works, fails, or raises exceptions.
     """
 
-    @patch("health_check.cache.backends.cache", MockCache())
+    @patch("health_check.cache.backends.caches", dict(default=MockCache()))
     def test_check_status_working(self):
         cache_backend = CacheBackend()
         cache_backend.run_check()
         self.assertFalse(cache_backend.errors)
 
+    @patch("health_check.cache.backends.caches", dict(default=MockCache(), broken=MockCache(set_works=False)))
+    def test_multiple_backends_check_default(self):
+        # default backend works while other is broken
+        cache_backend = CacheBackend('default')
+        cache_backend.run_check()
+        self.assertFalse(cache_backend.errors)
+
+    @patch("health_check.cache.backends.caches", dict(default=MockCache(), broken=MockCache(set_works=False)))
+    def test_multiple_backends_check_broken(self):
+        cache_backend = CacheBackend('broken')
+        cache_backend.run_check()
+        self.assertTrue(cache_backend.errors)
+        self.assertIn('unavailable: Cache key does not match', cache_backend.pretty_status())
+
     # check_status should raise ServiceUnavailable when values at cache key do not match
-    @patch("health_check.cache.backends.cache", MockCache(set_works=False))
+    @patch("health_check.cache.backends.caches", dict(default=MockCache(set_works=False)))
     def test_set_fails(self):
         cache_backend = CacheBackend()
         cache_backend.run_check()
@@ -60,14 +74,14 @@ class HealthCheckCacheTests(TestCase):
         self.assertIn('unavailable: Cache key does not match', cache_backend.pretty_status())
 
     # check_status should catch generic exceptions raised by set and convert to ServiceUnavailable
-    @patch("health_check.cache.backends.cache", MockCache(set_raises=Exception))
+    @patch("health_check.cache.backends.caches", dict(default=MockCache(set_raises=Exception)))
     def test_set_raises_generic(self):
         cache_backend = CacheBackend()
         with self.assertRaises(Exception):
             cache_backend.run_check()
 
     # check_status should catch CacheKeyWarning and convert to ServiceReturnedUnexpectedResult
-    @patch("health_check.cache.backends.cache", MockCache(set_raises=CacheKeyWarning))
+    @patch("health_check.cache.backends.caches", dict(default=MockCache(set_raises=CacheKeyWarning)))
     def test_set_raises_cache_key_warning(self):
         cache_backend = CacheBackend()
         cache_backend.check_status()


### PR DESCRIPTION
First draft of what we see as a gap in functionality in this library. We do still use it heavily for our services. 

Here we didn't see a problem with one of the non-default cache backends quickly enough. 

I'm happy to change / improve where you deem it necessary. 


We do have this code running in production, so there is no time pressure, let's make it right :) 