### PR TITLE
Celery health check: use ping instead of executing a task

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -70,6 +70,7 @@ Add the ``health_check`` applications to your ``INSTALLED_APPS``:
         'health_check.storage',
         'health_check.contrib.migrations',
         'health_check.contrib.celery',              # requires celery
+        'health_check.contrib.celery_ping',         # requires celery
         'health_check.contrib.psutil',              # disk and memory utilization; requires psutil
         'health_check.contrib.s3boto3_storage',     # requires boto3 and S3BotoStorage backend
         'health_check.contrib.rabbitmq',            # requires RabbitMQ broker

--- a/README.rst
+++ b/README.rst
@@ -15,6 +15,7 @@ The following health checks are bundled with this project:
 - disk and memory utilization (via ``psutil``)
 - AWS S3 storage
 - Celery task queue
+- Celery ping
 - RabbitMQ
 - Migrations
 

--- a/docs/contrib.rst
+++ b/docs/contrib.rst
@@ -35,3 +35,24 @@ to disable any of these checks, set its value to ``None``.
         'DISK_USAGE_MAX': 90,  # percent
         'MEMORY_MIN' = 100,    # in MB
     }
+
+``celery``
+----------
+
+If you are using Celery you may choose between two different Celery checks.
+
+`health_check.contrib.celery` sends a task to the queue and it expects that task
+to be executed in `HEALTHCHECK_CELERY_TIMEOUT` seconds which by default is three seconds.
+You may override that in your Django settings module. This check is suitable for use cases
+which require that tasks can be processed frequently all the time.
+
+`health_check.contrib.celery_ping` is a different check. It checks that each predefined
+Celery task queue has a consumer (i.e. worker) that responds `{"ok": "pong"}` in
+`HEALTHCHECK_CELERY_PING_TIMEOUT` seconds. The default for this is one second.
+You may override that in your Django settings module. This check is suitable for use cases
+which don't require that tasks are executed almost instantly but require that they are going
+to be executed in sometime the future i.e. that the worker process is alive and processing tasks
+all the time.
+
+You may also use both of them. To use these checks add them to `INSTALLED_APPS` in your
+Django settings module.

--- a/health_check/contrib/celery_ping/__init__.py
+++ b/health_check/contrib/celery_ping/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'health_check.contrib.celery_ping.apps.HealthCheckConfig'

--- a/health_check/contrib/celery_ping/apps.py
+++ b/health_check/contrib/celery_ping/apps.py
@@ -1,0 +1,12 @@
+from django.apps import AppConfig
+
+from health_check.plugins import plugin_dir
+
+
+class HealthCheckConfig(AppConfig):
+    name = 'health_check.contrib.celery_ping'
+
+    def ready(self):
+        from .backends import CeleryPingHealthCheck
+
+        plugin_dir.register(CeleryPingHealthCheck)

--- a/health_check/contrib/celery_ping/backends.py
+++ b/health_check/contrib/celery_ping/backends.py
@@ -6,24 +6,61 @@ from health_check.exceptions import ServiceUnavailable
 
 
 class CeleryPingHealthCheck(BaseHealthCheckBackend):
+    CORRECT_PING_RESPONSE = {"ok": "pong"}
 
     def check_status(self):
-        timeout = getattr(settings, 'HEALTHCHECK_CELERY_PING_TIMEOUT', 1)
+        timeout = getattr(settings, "HEALTHCHECK_CELERY_PING_TIMEOUT", 1)
+
         try:
             ping_result = app.control.ping(timeout=timeout)
         except IOError as e:
-            self.add_error(ServiceUnavailable('IOError'), e)
+            self.add_error(ServiceUnavailable("IOError"), e)
         except NotImplementedError as exc:
             self.add_error(
                 ServiceUnavailable(
-                    'NotImplementedError: Make sure CELERY_RESULT_BACKEND is set'
+                    "NotImplementedError: Make sure CELERY_RESULT_BACKEND is set"
                 ),
                 exc,
             )
         except BaseException as exc:
-            self.add_error(ServiceUnavailable('Unknown error'), exc)
+            self.add_error(ServiceUnavailable("Unknown error"), exc)
         else:
             if not ping_result:
                 self.add_error(
-                    ServiceUnavailable('Celery workers unavailable'),
+                    ServiceUnavailable("Celery workers unavailable"),
                 )
+            else:
+                self._check_ping_result(ping_result)
+
+    def _check_ping_result(self, ping_result):
+        active_workers = []
+
+        for worker, response in ping_result[0].items():
+            if response != self.CORRECT_PING_RESPONSE:
+                self.add_error(
+                    ServiceUnavailable(
+                        f"Celery worker {worker} response was incorrect"
+                    ),
+                )
+                continue
+            active_workers.append(worker)
+
+        if not self.errors:
+            self._check_active_queues(active_workers)
+
+    def _check_active_queues(self, active_workers):
+        defined_queues = app.conf.CELERY_QUEUES
+
+        if not defined_queues:
+            return
+
+        defined_queues = set([queue.name for queue in defined_queues])
+        active_queues = set()
+
+        for queues in app.control.inspect(active_workers).active_queues().values():
+            active_queues.update([queue.get("name") for queue in queues])
+
+        for queue in defined_queues.difference(active_queues):
+            self.add_error(
+                ServiceUnavailable(f"No worker for Celery task queue {queue}"),
+            )

--- a/health_check/contrib/celery_ping/backends.py
+++ b/health_check/contrib/celery_ping/backends.py
@@ -1,12 +1,8 @@
 from django.conf import settings
 
+from celery.app import default_app as app
 from health_check.backends import BaseHealthCheckBackend
 from health_check.exceptions import ServiceUnavailable
-
-try:
-    from celery.app import default_app as app
-except ImportError:
-    from celery import current_app as app
 
 
 class CeleryPingHealthCheck(BaseHealthCheckBackend):

--- a/health_check/contrib/celery_ping/backends.py
+++ b/health_check/contrib/celery_ping/backends.py
@@ -1,6 +1,6 @@
+from celery.app import default_app as app
 from django.conf import settings
 
-from celery.app import default_app as app
 from health_check.backends import BaseHealthCheckBackend
 from health_check.exceptions import ServiceUnavailable
 

--- a/health_check/contrib/celery_ping/backends.py
+++ b/health_check/contrib/celery_ping/backends.py
@@ -1,0 +1,33 @@
+from django.conf import settings
+
+try:
+    from celery.app import default_app as app
+except ImportError:
+    from celery import current_app as app
+
+from health_check.backends import BaseHealthCheckBackend
+from health_check.exceptions import ServiceUnavailable
+
+
+class CeleryPingHealthCheck(BaseHealthCheckBackend):
+
+    def check_status(self):
+        timeout = getattr(settings, 'HEALTHCHECK_CELERY_PING_TIMEOUT', 1)
+        try:
+            ping_result = app.control.ping(timeout=timeout)
+        except IOError as e:
+            self.add_error(ServiceUnavailable('IOError'), e)
+        except NotImplementedError as exc:
+            self.add_error(
+                ServiceUnavailable(
+                    'NotImplementedError: Make sure CELERY_RESULT_BACKEND is set'
+                ),
+                exc,
+            )
+        except BaseException as exc:
+            self.add_error(ServiceUnavailable('Unknown error'), exc)
+        else:
+            if not ping_result:
+                self.add_error(
+                    ServiceUnavailable('Celery workers unavailable'),
+                )

--- a/health_check/contrib/celery_ping/backends.py
+++ b/health_check/contrib/celery_ping/backends.py
@@ -1,12 +1,12 @@
 from django.conf import settings
 
+from health_check.backends import BaseHealthCheckBackend
+from health_check.exceptions import ServiceUnavailable
+
 try:
     from celery.app import default_app as app
 except ImportError:
     from celery import current_app as app
-
-from health_check.backends import BaseHealthCheckBackend
-from health_check.exceptions import ServiceUnavailable
 
 
 class CeleryPingHealthCheck(BaseHealthCheckBackend):

--- a/tests/test_autodiscover.py
+++ b/tests/test_autodiscover.py
@@ -7,17 +7,19 @@ from health_check.plugins import plugin_dir
 
 
 class TestAutoDiscover:
+
     def test_autodiscover(self):
         health_check_plugins = list(filter(
-            lambda x: 'health_check.' in x and 'celery' or 'celery_ping' not in x,
+            lambda x: x.startswith('health_check.') and 'celery' not in x,
             settings.INSTALLED_APPS
         ))
 
-        non_celery_plugins = [x for x in plugin_dir._registry if not issubclass(x[0], (CeleryHealthCheck, CeleryPingHealthCheck))]
+        non_celery_plugins = [x for x in plugin_dir._registry
+                              if not issubclass(x[0], (CeleryHealthCheck, CeleryPingHealthCheck))]
 
         # The number of installed apps excluding celery should equal to all plugins except celery
         assert len(non_celery_plugins) == len(health_check_plugins)
 
     def test_discover_celery_queues(self):
-        celery_plugins = [x for x in plugin_dir._registry if issubclass(x[0], (CeleryHealthCheck, CeleryPingHealthCheck))]
-        assert len(celery_plugins) == 2
+        celery_plugins = [x for x in plugin_dir._registry if issubclass(x[0], CeleryHealthCheck)]
+        assert len(celery_plugins) == len(current_app.amqp.queues)

--- a/tests/test_autodiscover.py
+++ b/tests/test_autodiscover.py
@@ -2,21 +2,22 @@ from celery import current_app
 from django.conf import settings
 
 from health_check.contrib.celery.backends import CeleryHealthCheck
+from health_check.contrib.celery_ping.backends import CeleryPingHealthCheck
 from health_check.plugins import plugin_dir
 
 
 class TestAutoDiscover:
     def test_autodiscover(self):
         health_check_plugins = list(filter(
-            lambda x: 'health_check.' in x and 'celery' not in x,
+            lambda x: 'health_check.' in x and 'celery' or 'celery_ping' not in x,
             settings.INSTALLED_APPS
         ))
 
-        non_celery_plugins = [x for x in plugin_dir._registry if not issubclass(x[0], CeleryHealthCheck)]
+        non_celery_plugins = [x for x in plugin_dir._registry if not issubclass(x[0], (CeleryHealthCheck, CeleryPingHealthCheck))]
 
         # The number of installed apps excluding celery should equal to all plugins except celery
         assert len(non_celery_plugins) == len(health_check_plugins)
 
     def test_discover_celery_queues(self):
-        celery_plugins = [x for x in plugin_dir._registry if issubclass(x[0], CeleryHealthCheck)]
-        assert len(celery_plugins) == len(current_app.amqp.queues)
+        celery_plugins = [x for x in plugin_dir._registry if issubclass(x[0], (CeleryHealthCheck, CeleryPingHealthCheck))]
+        assert len(celery_plugins) == 2

--- a/tests/test_celery_ping.py
+++ b/tests/test_celery_ping.py
@@ -1,0 +1,72 @@
+import pytest
+
+from health_checks.contrib.celery_ping.backends import CeleryPingHealthCheck
+
+CELERY_HEALTH_CHECK_MODULE = 'apps.health_checks.backends.celery.'
+
+
+class TestCeleryWorkersHealthCheck:
+    health_check_class = CeleryPingHealthCheck
+    CELERY_HEALTH_CHECK_MODULE = \
+        'health_checks.contrib.celery_ping.backends.app.control.ping'
+
+    def test_check_status_doesnt_add_errors_when_ping_successfull(
+            self, mocker):
+        mocker.patch(
+            self.CELERY_HEALTH_CHECK_MODULE,
+            return_value=[{'celery@4cc150a7b49b': {'ok': 'pong'}}])
+
+        health_check = self.health_check_class()
+        health_check.check_status()
+
+        assert len(health_check.errors) == 0
+
+    @pytest.mark.parametrize('exception_to_raise', [
+        IOError,
+        TimeoutError,
+    ])
+    def test_check_status_add_error_when_io_error_raised_from_ping(
+            self, mocker, exception_to_raise):
+        mocker.patch(
+            self.CELERY_HEALTH_CHECK_MODULE,
+            side_effect=exception_to_raise)
+
+        health_check = self.health_check_class()
+        health_check.check_status()
+
+        assert len(health_check.errors) == 1
+        assert 'ioerror' in health_check.errors[0].message.lower()
+
+    @pytest.mark.parametrize('exception_to_raise', [
+        ValueError,
+        SystemError,
+        IndexError,
+        MemoryError,
+    ])
+    def test_check_status_add_error_when_any_exception_raised_from_ping(
+            self, mocker, exception_to_raise):
+        mocker.patch(
+            self.CELERY_HEALTH_CHECK_MODULE,
+            side_effect=exception_to_raise)
+
+        health_check = self.health_check_class()
+        health_check.check_status()
+
+        assert len(health_check.errors) == 1
+        assert health_check.errors[0].message.lower() == 'unknown error'
+
+    @pytest.mark.parametrize('ping_result', [
+        None,
+        list()
+    ])
+    def test_check_status_add_error_when_ping_result_failed(
+            self, mocker, ping_result):
+        mocker.patch(
+            self.CELERY_HEALTH_CHECK_MODULE,
+            return_value=ping_result)
+
+        health_check = self.health_check_class()
+        health_check.check_status()
+
+        assert len(health_check.errors) == 1
+        assert 'workers unavailable' in health_check.errors[0].message.lower()

--- a/tests/test_celery_ping.py
+++ b/tests/test_celery_ping.py
@@ -1,5 +1,6 @@
 import pytest
 from django.apps import apps
+from django.conf import settings
 from mock import patch
 
 from health_check.contrib.celery_ping.apps import HealthCheckConfig
@@ -7,78 +8,123 @@ from health_check.contrib.celery_ping.backends import CeleryPingHealthCheck
 
 
 class TestCeleryPingHealthCheck:
-    health_check_class = CeleryPingHealthCheck
-    CELERY_HEALTH_CHECK_MODULE = \
-        'health_check.contrib.celery_ping.backends.app.control.ping'
+    CELERY_APP_CONTROL_PING = (
+        "health_check.contrib.celery_ping.backends.app.control.ping"
+    )
+    CELERY_APP_CONTROL_INSPECT_ACTIVE_QUEUES = (
+        "health_check.contrib.celery_ping.backends.app.control.inspect.active_queues"
+    )
 
-    def test_check_status_doesnt_add_errors_when_ping_successfull(self):
-        with patch(self.CELERY_HEALTH_CHECK_MODULE,
-                   return_value=[{'celery@4cc150a7b49b': {'ok': 'pong'}}]):
-            health_check = self.health_check_class()
+    @pytest.fixture
+    def health_check(self):
+        return CeleryPingHealthCheck()
+
+    def test_check_status_doesnt_add_errors_when_ping_successfull(self, health_check):
+        celery_worker = "celery@4cc150a7b49b"
+
+        with patch(
+            self.CELERY_APP_CONTROL_PING,
+            return_value=[{celery_worker: CeleryPingHealthCheck.CORRECT_PING_RESPONSE}],
+        ), patch(
+            self.CELERY_APP_CONTROL_INSPECT_ACTIVE_QUEUES,
+            return_value={
+                celery_worker: [
+                    {"name": queue.name} for queue in settings.CELERY_QUEUES
+                ]
+            },
+        ):
             health_check.check_status()
 
-            assert len(health_check.errors) == 0
+            assert not health_check.errors
 
-    @pytest.mark.parametrize('exception_to_raise', [
-        IOError,
-        TimeoutError,
-    ])
+    def test_check_status_reports_errors_if_ping_responses_are_incorrect(
+        self, health_check
+    ):
+        with patch(
+            self.CELERY_APP_CONTROL_PING,
+            return_value=[
+                {
+                    "celery1@4cc150a7b49b": CeleryPingHealthCheck.CORRECT_PING_RESPONSE,
+                    "celery2@4cc150a7b49b": {},
+                    "celery3@4cc150a7b49b": {"error": "pong"},
+                }
+            ],
+        ):
+            health_check.check_status()
+
+            assert len(health_check.errors) == 2
+
+    def test_check_status_adds_errors_when_ping_successfull_but_not_all_defined_queues_have_consumers(
+        self,
+        health_check,
+    ):
+        celery_worker = "celery@4cc150a7b49b"
+        queues = list(settings.CELERY_QUEUES)
+
+        with patch(
+            self.CELERY_APP_CONTROL_PING,
+            return_value=[{celery_worker: CeleryPingHealthCheck.CORRECT_PING_RESPONSE}],
+        ), patch(
+            self.CELERY_APP_CONTROL_INSPECT_ACTIVE_QUEUES,
+            return_value={celery_worker: [{"name": queues.pop().name}]},
+        ):
+            health_check.check_status()
+
+            assert len(health_check.errors) == len(queues)
+
+    @pytest.mark.parametrize(
+        "exception_to_raise",
+        [
+            IOError,
+            TimeoutError,
+        ],
+    )
     def test_check_status_add_error_when_io_error_raised_from_ping(
-            self, exception_to_raise):
-        with patch(self.CELERY_HEALTH_CHECK_MODULE,
-                   side_effect=exception_to_raise):
-            health_check = self.health_check_class()
+        self, exception_to_raise, health_check
+    ):
+        with patch(self.CELERY_APP_CONTROL_PING, side_effect=exception_to_raise):
             health_check.check_status()
 
             assert len(health_check.errors) == 1
-            assert 'ioerror' in health_check.errors[0].message.lower()
+            assert "ioerror" in health_check.errors[0].message.lower()
 
-    @pytest.mark.parametrize('exception_to_raise', [
-        ValueError,
-        SystemError,
-        IndexError,
-        MemoryError
-    ])
+    @pytest.mark.parametrize(
+        "exception_to_raise", [ValueError, SystemError, IndexError, MemoryError]
+    )
     def test_check_status_add_error_when_any_exception_raised_from_ping(
-            self, exception_to_raise):
-        with patch(self.CELERY_HEALTH_CHECK_MODULE,
-                   side_effect=exception_to_raise):
-            health_check = self.health_check_class()
+        self, exception_to_raise, health_check
+    ):
+        with patch(self.CELERY_APP_CONTROL_PING, side_effect=exception_to_raise):
             health_check.check_status()
 
             assert len(health_check.errors) == 1
-            assert health_check.errors[0].message.lower() == 'unknown error'
+            assert health_check.errors[0].message.lower() == "unknown error"
 
-    def test_check_status_when_raised_exception_notimplementederror(self):
-        msg = 'notimplementederror: make sure celery_result_backend is set'
+    def test_check_status_when_raised_exception_notimplementederror(self, health_check):
+        expected_error_message = (
+            "notimplementederror: make sure celery_result_backend is set"
+        )
 
-        with patch(self.CELERY_HEALTH_CHECK_MODULE,
-                   side_effect=NotImplementedError):
-            health_check = self.health_check_class()
+        with patch(self.CELERY_APP_CONTROL_PING, side_effect=NotImplementedError):
             health_check.check_status()
 
             assert len(health_check.errors) == 1
-            assert health_check.errors[0].message.lower() == msg
+            assert health_check.errors[0].message.lower() == expected_error_message
 
-    @pytest.mark.parametrize('ping_result', [
-        None,
-        list()
-    ])
+    @pytest.mark.parametrize("ping_result", [None, list()])
     def test_check_status_add_error_when_ping_result_failed(
-            self, ping_result):
-        with patch(self.CELERY_HEALTH_CHECK_MODULE,
-                   return_value=ping_result):
-            health_check = self.health_check_class()
+        self, ping_result, health_check
+    ):
+        with patch(self.CELERY_APP_CONTROL_PING, return_value=ping_result):
             health_check.check_status()
 
             assert len(health_check.errors) == 1
-            assert 'workers unavailable' in health_check.errors[0].message.lower()
+            assert "workers unavailable" in health_check.errors[0].message.lower()
 
 
 class TestCeleryPingHealthCheckApps:
-
     def test_apps(self):
-        assert HealthCheckConfig.name == 'health_check.contrib.celery_ping'
+        assert HealthCheckConfig.name == "health_check.contrib.celery_ping"
 
-        celery_ping = apps.get_app_config('celery_ping')
-        assert celery_ping.name == 'health_check.contrib.celery_ping'
+        celery_ping = apps.get_app_config("celery_ping")
+        assert celery_ping.name == "health_check.contrib.celery_ping"

--- a/tests/test_celery_ping.py
+++ b/tests/test_celery_ping.py
@@ -1,7 +1,7 @@
 import pytest
+from mock import patch
 
 from health_check.contrib.celery_ping.backends import CeleryPingHealthCheck
-from mock import patch
 
 
 class TestCeleryWorkersHealthCheck:

--- a/tests/test_celery_ping.py
+++ b/tests/test_celery_ping.py
@@ -1,6 +1,7 @@
 import pytest
 
 from health_check.contrib.celery_ping.backends import CeleryPingHealthCheck
+from mock import patch
 
 
 class TestCeleryWorkersHealthCheck:
@@ -8,32 +9,27 @@ class TestCeleryWorkersHealthCheck:
     CELERY_HEALTH_CHECK_MODULE = \
         'health_check.contrib.celery_ping.backends.app.control.ping'
 
-    def test_check_status_doesnt_add_errors_when_ping_successfull(
-            self, mocker):
-        mocker.patch(
-            self.CELERY_HEALTH_CHECK_MODULE,
-            return_value=[{'celery@4cc150a7b49b': {'ok': 'pong'}}])
+    def test_check_status_doesnt_add_errors_when_ping_successfull(self):
+        with patch(self.CELERY_HEALTH_CHECK_MODULE,
+                   return_value=[{'celery@4cc150a7b49b': {'ok': 'pong'}}]):
+            health_check = self.health_check_class()
+            health_check.check_status()
 
-        health_check = self.health_check_class()
-        health_check.check_status()
-
-        assert len(health_check.errors) == 0
+            assert len(health_check.errors) == 0
 
     @pytest.mark.parametrize('exception_to_raise', [
         IOError,
         TimeoutError,
     ])
     def test_check_status_add_error_when_io_error_raised_from_ping(
-            self, mocker, exception_to_raise):
-        mocker.patch(
-            self.CELERY_HEALTH_CHECK_MODULE,
-            side_effect=exception_to_raise)
+            self, exception_to_raise):
+        with patch(self.CELERY_HEALTH_CHECK_MODULE,
+                   side_effect=exception_to_raise):
+            health_check = self.health_check_class()
+            health_check.check_status()
 
-        health_check = self.health_check_class()
-        health_check.check_status()
-
-        assert len(health_check.errors) == 1
-        assert 'ioerror' in health_check.errors[0].message.lower()
+            assert len(health_check.errors) == 1
+            assert 'ioerror' in health_check.errors[0].message.lower()
 
     @pytest.mark.parametrize('exception_to_raise', [
         ValueError,
@@ -42,29 +38,25 @@ class TestCeleryWorkersHealthCheck:
         MemoryError,
     ])
     def test_check_status_add_error_when_any_exception_raised_from_ping(
-            self, mocker, exception_to_raise):
-        mocker.patch(
-            self.CELERY_HEALTH_CHECK_MODULE,
-            side_effect=exception_to_raise)
+            self, exception_to_raise):
+        with patch(self.CELERY_HEALTH_CHECK_MODULE,
+                   side_effect=exception_to_raise):
+            health_check = self.health_check_class()
+            health_check.check_status()
 
-        health_check = self.health_check_class()
-        health_check.check_status()
-
-        assert len(health_check.errors) == 1
-        assert health_check.errors[0].message.lower() == 'unknown error'
+            assert len(health_check.errors) == 1
+            assert health_check.errors[0].message.lower() == 'unknown error'
 
     @pytest.mark.parametrize('ping_result', [
         None,
         list()
     ])
     def test_check_status_add_error_when_ping_result_failed(
-            self, mocker, ping_result):
-        mocker.patch(
-            self.CELERY_HEALTH_CHECK_MODULE,
-            return_value=ping_result)
+            self, ping_result):
+        with patch(self.CELERY_HEALTH_CHECK_MODULE,
+                   return_value=ping_result):
+            health_check = self.health_check_class()
+            health_check.check_status()
 
-        health_check = self.health_check_class()
-        health_check.check_status()
-
-        assert len(health_check.errors) == 1
-        assert 'workers unavailable' in health_check.errors[0].message.lower()
+            assert len(health_check.errors) == 1
+            assert 'workers unavailable' in health_check.errors[0].message.lower()

--- a/tests/test_celery_ping.py
+++ b/tests/test_celery_ping.py
@@ -1,14 +1,12 @@
 import pytest
 
-from health_checks.contrib.celery_ping.backends import CeleryPingHealthCheck
-
-CELERY_HEALTH_CHECK_MODULE = 'apps.health_checks.backends.celery.'
+from health_check.contrib.celery_ping.backends import CeleryPingHealthCheck
 
 
 class TestCeleryWorkersHealthCheck:
     health_check_class = CeleryPingHealthCheck
     CELERY_HEALTH_CHECK_MODULE = \
-        'health_checks.contrib.celery_ping.backends.app.control.ping'
+        'health_check.contrib.celery_ping.backends.app.control.ping'
 
     def test_check_status_doesnt_add_errors_when_ping_successfull(
             self, mocker):

--- a/tests/test_celery_ping.py
+++ b/tests/test_celery_ping.py
@@ -1,10 +1,9 @@
-from django.apps import apps
-
 import pytest
+from django.apps import apps
+from mock import patch
 
 from health_check.contrib.celery_ping.apps import HealthCheckConfig
 from health_check.contrib.celery_ping.backends import CeleryPingHealthCheck
-from mock import patch
 
 
 class TestCeleryPingHealthCheck:

--- a/tests/testapp/celery.py
+++ b/tests/testapp/celery.py
@@ -1,4 +1,4 @@
 from celery import Celery
 
-app = Celery('testapp')
+app = Celery('testapp', broker='memory://')
 app.config_from_object('django.conf:settings', namespace='CELERY')

--- a/tests/testapp/settings.py
+++ b/tests/testapp/settings.py
@@ -28,6 +28,7 @@ INSTALLED_APPS = (
     'health_check.storage',
     'health_check.contrib.celery',
     'health_check.contrib.migrations',
+    'health_check.contrib.celery_ping',
     'health_check.contrib.s3boto_storage',
     'tests',
 )

--- a/tests/testapp/settings.py
+++ b/tests/testapp/settings.py
@@ -2,6 +2,8 @@
 import os.path
 import uuid
 
+from kombu import Queue
+
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 DEBUG = True
 
@@ -60,7 +62,7 @@ SECRET_KEY = uuid.uuid4().hex
 
 USE_L10N = True
 
-CELERY_TASK_QUEUES = {
-    'default': {},
-    'queue2': {}
-}
+CELERY_QUEUES = [
+    Queue('default'),
+    Queue('queue2'),
+]


### PR DESCRIPTION
Workers might be busy which would cause the previous health check task to timeout or expire. That doesn't mean the worker (the node / main process) is dead. The ping responses are validated and predefined queues are checked so that each one of them should have at least one consumer.

Based on top of https://github.com/KristianOellegaard/django-health-check/pull/209