### PR TITLE
Addresses issue #265 - Django 4.0 deprecation warning

### DIFF
--- a/health_check/urls.py
+++ b/health_check/urls.py
@@ -1,9 +1,9 @@
-from django.conf.urls import url
+from django.urls import path
 
 from health_check.views import MainView
 
 app_name = 'health_check'
 
 urlpatterns = [
-    url(r'^$', MainView.as_view(), name='health_check_home'),
+    path('', MainView.as_view(), name='health_check_home'),
 ]


### PR DESCRIPTION
Updated `health_check/urls.py` to use `django.urls.path` instead of `django.conf.urls.url` for defining urlpatterns, as the latter will be deprecated in Django 4.0.