### PR TITLE
Decode redis_url

### DIFF
--- a/health_check/contrib/redis/backends.py
+++ b/health_check/contrib/redis/backends.py
@@ -21,7 +21,7 @@ class RedisHealthCheck(BaseHealthCheckBackend):
         logger.debug("Attempting to connect to redis...")
         try:
             # conn is used as a context to release opened resources later
-            with from_url(self.redis_url) as conn:
+            with from_url(self.redis_url, decode_components=True) as conn:
                 conn.ping()  # exceptions may be raised upon ping
         except ConnectionRefusedError as e:
             self.add_error(ServiceUnavailable("Unable to connect to Redis: Connection was refused."), e)


### PR DESCRIPTION
For now, it won't work correctly with any redis_url that contains uri reserved characters (usually in password).

According to [RFC3986 Section 3.2.1](https://tools.ietf.org/html/rfc3986#section-3.2.1):
> userinfo    = *( unreserved / pct-encoded / sub-delims / ":" )

So any reserved characters in userinfo must be encoded. The same, any '%' in uri should be regard as encoded-escape character.

There is a `reids-py@4.0` version that still in development has fixed it, `redis-py@4.0` will always decode url. https://github.com/andymccurdy/redis-py/issues/589

But in the stable `redis-py`, it only provides an optional argument `decode_components=False` to implement url decoding. So we should set it `True`.


Another accordance: [celery](https://github.com/celery/celery) does decode redis_url automatically.