### PR TITLE
Add simple endpoint to check if application is initialized

### DIFF
--- a/health_check/urls.py
+++ b/health_check/urls.py
@@ -1,9 +1,10 @@
 from django.urls import path
 
-from health_check.views import MainView
+from health_check.views import MainView, ping
 
 app_name = 'health_check'
 
 urlpatterns = [
     path('', MainView.as_view(), name='health_check_home'),
+    path('ping', ping, name='health_check_ping'),
 ]

--- a/health_check/views.py
+++ b/health_check/views.py
@@ -110,3 +110,6 @@ class MainView(CheckMixin, TemplateView):
             {str(p.identifier()): str(p.pretty_status()) for p in plugins},
             status=status
         )
+
+def ping(request):
+    return HttpResponse('pong')

--- a/tests/test_ping.py
+++ b/tests/test_ping.py
@@ -1,0 +1,11 @@
+from django.urls import reverse
+from django.test import TestCase
+
+
+class TestPingHealthCheck(TestCase):
+    url = reverse('health_check:health_check_ping')
+
+    def test_check_status_works(self):
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        assert response.content == b'pong'


### PR DESCRIPTION
This is a lightweight endpoint that can be used by services to monitor the uptime of an application without going through the full gamut of healthchecks. It's meant for using in something like a k8s cluster where you want a simple endpoint to know an application has been initialized, or to continually probe for uptime.