### PR TITLE
Added text align right for time col

### DIFF
--- a/health_check/templates/health_check/index.html
+++ b/health_check/templates/health_check/index.html
@@ -13,7 +13,7 @@
       <tr class="w3-blue">
         <th colspan="2">Service</th>
         <th>Status</th>
-        <th class="w3-hide-small w3-hide-medium w3-right">Time Taken</th>
+        <th class="w3-hide-small w3-hide-medium w3-right w3-right-align">Time Taken</th>
       </tr>
       {% for plugin in plugins %}
         <tr>
@@ -26,7 +26,7 @@
           </td>
           <td>{{ plugin.identifier }}</td>
           <td>{{ plugin.pretty_status }}</td>
-          <td class="w3-hide-small w3-hide-medium w3-right">{{ plugin.time_taken|floatformat:4 }} seconds</td>
+          <td class="w3-hide-small w3-hide-medium w3-right w3-right-align">{{ plugin.time_taken|floatformat:4 }} seconds</td>
         </tr>
       {% endfor %}
     </table>


### PR DESCRIPTION
The w3-right class does not specific a text alignment, which makes the time values to be misaligned in certain browsers like safari.

so added w3-right-align to for text align to right in last col for time taken.

Note: even without w3-right-align Firefox and chrome aligns the text to right, the issue was noticed in safari. Attached screen shot for reference.

![Screenshot 2021-01-06 at 12 12 05 PM](https://user-images.githubusercontent.com/1151263/103737584-78bcac00-5018-11eb-8bcf-ffa748587aa1.png)
