### PR TITLE
Inject context dict to plugin if it has a set_context method

### DIFF
--- a/health_check/backends.py
+++ b/health_check/backends.py
@@ -19,6 +19,7 @@ class BaseHealthCheckBackend:
 
     def __init__(self):
         self.errors = []
+        self.context = {}
 
     def check_status(self):
         raise NotImplementedError
@@ -55,6 +56,9 @@ class BaseHealthCheckBackend:
         if self.errors:
             return "\n".join(str(e) for e in self.errors)
         return _('working')
+
+    def set_context(self, context):
+        self.context = context
 
     @property
     def status(self):

--- a/health_check/mixins.py
+++ b/health_check/mixins.py
@@ -29,6 +29,8 @@ class CheckMixin:
         errors = []
 
         def _run(plugin):
+            if hasattr(plugin, "set_context") and callable(plugin.set_context):
+                plugin.set_context(self.get_plugin_context(plugin_name=plugin.identifier()))
             plugin.run_check()
             try:
                 return plugin
@@ -48,3 +50,7 @@ class CheckMixin:
                         errors.extend(plugin.errors)
 
         return errors
+
+    def get_plugin_context(self, plugin_name):
+        context = {}
+        return context


### PR DESCRIPTION
Hi @codingjoe 

About #290 I came up with this.

If you need to inject something to your plugin you would

1. subclass the view and create a `get_plugin_context(plugin_name)` in it. In that method you can inject what you need. Since the plugin name is passed as an argument, you can customize what you inject for each plugin.
2. in your plugin you can now access `self.context` and override the `set_context()` method if needed.

What do you think?