### PR TITLE
Changed 'url' instances in docs and tests to 'path'.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,7 +56,7 @@ Add the health checker to a URL you want to use:
 
     urlpatterns = [
         # ...
-        url(r'^ht/', include('health_check.urls')),
+        path('ht/', include('health_check.urls')),
     ]
 
 Add the ``health_check`` applications to your ``INSTALLED_APPS``:
@@ -268,7 +268,7 @@ and customizing the ``template_name``, ``get``, ``render_to_response`` and ``ren
 
     urlpatterns = [
         # ...
-        url(r'^ht/$', views.HealthCheckCustomView.as_view(), name='health_check_custom'),
+        path('ht/', views.HealthCheckCustomView.as_view(), name='health_check_custom'),
     ]
 
 Django command

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -33,7 +33,7 @@ Add it to your URL:
 
     urlpatterns = [
         # ...
-        url(r'^ht/super_secret_token/'), include('health_check.urls')),
+        path('ht/super_secret_token/'), include('health_check.urls')),
     ]
 
 You can still use any uptime bot that is URL based while enjoying token protection.

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -18,7 +18,7 @@ class OkPlugin(BaseHealthCheckBackend):
 
 
 class TestCommand:
-    @pytest.yield_fixture(autouse=True)
+    @pytest.fixture(autouse=True)
     def setup(self):
         plugin_dir.reset()
         plugin_dir.register(FailPlugin)

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -20,7 +20,7 @@ class Checker(CheckMixin):
 
 
 class TestCheckMixin:
-    @pytest.yield_fixture(autouse=True)
+    @pytest.fixture(autouse=True)
     def setup(self):
         plugin_dir.reset()
         plugin_dir.register(FailPlugin)

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -15,7 +15,7 @@ class Plugin(BaseHealthCheckBackend):
 
 
 class TestPlugin:
-    @pytest.yield_fixture(autouse=True)
+    @pytest.fixture(autouse=True)
     def setup(self):
         plugin_dir.reset()
         plugin_dir.register(FakePlugin)

--- a/tests/testapp/urls.py
+++ b/tests/testapp/urls.py
@@ -1,5 +1,5 @@
-from django.conf.urls import include, url
+from django.urls import include, path
 
 urlpatterns = [
-    url(r'^ht/', include('health_check.urls')),
+    path('ht/', include('health_check.urls')),
 ]


### PR DESCRIPTION
'path' was introduced in django 2.0 (the minimum supported version for
django-health-check) as a simpler replacement for url and url was
officially deprecated in Django 3.1.