### PR TITLE
feat: allow setting Redis connection options

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,6 +16,7 @@ The following health checks are bundled with this project:
 - AWS S3 storage
 - Celery task queue
 - Celery ping
+- Redis
 - RabbitMQ
 - Migrations
 
@@ -110,6 +111,8 @@ on django.conf.settings with the required format to connect to your redis server
 .. code::
 
     REDIS_URL = redis://localhost:6370
+
+Additional connection options may be specified by defining a variable ``HEALTHCHECK_REDIS_URL_OPTIONS`` on the settings module.
 
 Setting up monitoring
 ---------------------

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -90,3 +90,21 @@ Using `django.settings` you may exert more fine-grained control over the behavio
      - Number
      - 3
      - Specifies the maximum total time for a task to complete and return a result, including queue time.
+
+Redis Health Check
+------------------
+
+The Redis health check allows customising the underlying connection:
+
+.. list-table:: Additional Settings
+   :widths: 25 10 10 55
+   :header-rows: 1
+
+   * - Name
+     - Type
+     - Default
+     - Description
+   * - `HEALTHCHECK_REDIS_URL_OPTIONS`
+     - Dict
+     - {}
+     - Additional arguments which will be passed as keyword arguments to the Redis connection class initialiser.

--- a/health_check/contrib/redis/backends.py
+++ b/health_check/contrib/redis/backends.py
@@ -13,6 +13,7 @@ class RedisHealthCheck(BaseHealthCheckBackend):
     """Health check for Redis."""
 
     redis_url = getattr(settings, "REDIS_URL", 'redis://localhost/1')
+    redis_url_options = getattr(settings, "HEALTHCHECK_REDIS_URL_OPTIONS", {})
 
     def check_status(self):
         """Check Redis service by pinging the redis instance with a redis connection."""
@@ -21,7 +22,7 @@ class RedisHealthCheck(BaseHealthCheckBackend):
         logger.debug("Attempting to connect to redis...")
         try:
             # conn is used as a context to release opened resources later
-            with from_url(self.redis_url) as conn:
+            with from_url(self.redis_url, **self.redis_url_options) as conn:
                 conn.ping()  # exceptions may be raised upon ping
         except ConnectionRefusedError as e:
             self.add_error(ServiceUnavailable("Unable to connect to Redis: Connection was refused."), e)


### PR DESCRIPTION
`redis.from_url` may accept [connection options](https://redis-py.readthedocs.io/en/stable/#redis.from_url) specified as kwargs. They're not particularly documented, but a list may be found in the [source code](https://github.com/andymccurdy/redis-py/blob/fc621bd1b4de35fa088f87895e5fa1ade6a9150c/redis/connection.py#L921-L930):
```
URL_QUERY_ARGUMENT_PARSERS = {
    'db': int,
    'socket_timeout': float,
    'socket_connect_timeout': float,
    'socket_keepalive': to_bool,
    'retry_on_timeout': to_bool,
    'max_connections': int,
    'health_check_interval': int,
    'ssl_check_hostname': to_bool,
}
```
I think most people don't need them and `django-health-check` works fine with the defaults.

That said, there is one particular case which I think `django-health-check` needs to deal with which is e.g. Heroku uses self signed certificates which causes the connection to fail (raising a `ConnectionError`) which in turn makes the Redis health check to report the service as unavailable. The issue can be [worked around by disabling SSL verification](https://help.heroku.com/HC0F8CUS/redis-connection-issues). In order to do that, one needs to pass `ssl_cert_reqs=None` to the connection object.

This PR introduces a new variable `HEALTHCHECK_REDIS_URL_OPTIONS` which allows one to customise the connection if they need to.