### PR TITLE
Improve test reliability by cleaning the state pollution of test_warning in TestMainView

### DIFF
--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -99,7 +99,7 @@ class TestMainView:
         assert response['content-type'] == 'text/html; charset=utf-8'
         assert b'Super Fail!' in response.content
 
-    def test_warning(self, client):
+    def test_warning(self, client, monkeypatch):
         class MyBackend(BaseHealthCheckBackend):
             def check_status(self):
                 raise ServiceWarning('so so')
@@ -110,7 +110,7 @@ class TestMainView:
         assert response.status_code == 500, response.content.decode('utf-8')
         assert b'so so' in response.content, response.content
 
-        HEALTH_CHECK['WARNINGS_AS_ERRORS'] = False
+        monkeypatch.setitem(HEALTH_CHECK, 'WARNINGS_AS_ERRORS', False)
 
         response = client.get(self.url)
         assert response.status_code == 200, response.content.decode('utf-8')


### PR DESCRIPTION
This PR aims to improve test reliability by cleaning the state pollution in `TestMainView.test_warning`. `HEALTH_CHECK['WARNINGS_AS_ERRORS']` is set to `TRUE` by default, but `test_warning` changes it to be `FALSE`. The fix is to restore the default value after running the test.