### PR TITLE
use celery `app_or_default` in `celery_ping` since it's more stable

### DIFF
--- a/health_check/contrib/celery_ping/backends.py
+++ b/health_check/contrib/celery_ping/backends.py
@@ -1,4 +1,4 @@
-from celery.app import default_app as app
+from celery.app import app_or_default
 from django.conf import settings
 
 from health_check.backends import BaseHealthCheckBackend
@@ -12,6 +12,7 @@ class CeleryPingHealthCheck(BaseHealthCheckBackend):
         timeout = getattr(settings, "HEALTHCHECK_CELERY_PING_TIMEOUT", 1)
 
         try:
+            app = app_or_default(None)
             ping_result = app.control.ping(timeout=timeout)
         except IOError as e:
             self.add_error(ServiceUnavailable("IOError"), e)
@@ -50,6 +51,8 @@ class CeleryPingHealthCheck(BaseHealthCheckBackend):
             self._check_active_queues(active_workers)
 
     def _check_active_queues(self, active_workers):
+        app = app_or_default(None)
+
         defined_queues = app.conf.CELERY_QUEUES
 
         if not defined_queues:


### PR DESCRIPTION
I was debugging a problem I had in one of our applications, and it looked like sometimes `celery.app.default_app` is `None` in our case, switching without changing code. Locally I could reproduce it, but while searching I saw that the official method to get the default app [`celery.app.app_or_default`](https://docs.celeryproject.org/en/stable/reference/celery.app.html#celery.app.app_or_default) always returns the valid result. 

Since this is the correct API I believe we should change the method used here. 