### PR TITLE
Add proper line breaks to the pretty_status HTML

### DIFF
--- a/health_check/templates/health_check/index.html
+++ b/health_check/templates/health_check/index.html
@@ -26,7 +26,7 @@
             {% endif %}
           </td>
           <td>{{ plugin.identifier }}</td>
-          <td>{{ plugin.pretty_status }}</td>
+          <td>{{ plugin.pretty_status | linebreaks }}</td>
           <td class="w3-hide-small w3-hide-medium w3-right w3-right-align">{{ plugin.time_taken|floatformat:4 }} seconds</td>
         </tr>
       {% endfor %}


### PR DESCRIPTION
since `pretty_status` returns linebreak-ed string, I think it makes sense to add `linebreak` in the default template. 