### PR TITLE
Use default number of `max_workers`

### DIFF
--- a/health_check/mixins.py
+++ b/health_check/mixins.py
@@ -84,7 +84,7 @@ class CheckMixin:
                 _run(plugin)
                 _collect_errors(plugin)
         else:
-            with ThreadPoolExecutor(max_workers=len(plugin_instances) or 1) as executor:
+            with ThreadPoolExecutor() as executor:
                 for plugin in executor.map(_run, plugin_instances):
                     _collect_errors(plugin)
         return errors


### PR DESCRIPTION
This allows Python to decide what the right number is, based on the number of CPU cores available.