### PR TITLE
CacheBackend: Use a configurable setting to specify cache key

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,13 @@ on django.conf.settings with the required format to connect to your redis server
     REDIS_URL = redis://localhost:6370
 ```
 
+The cache healthcheck tries to write and read a specific key within the cache backend.
+It can be customized by setting `HEALTHCHECK_CACHE_KEY` to another value:
+
+```python
+    HEALTHCHECK_CACHE_KEY = custom_healthcheck_key
+```
+
 ## Setting up monitoring
 
 You can use tools like Pingdom, StatusCake or other uptime robots to monitor service status.

--- a/docs/contrib.rst
+++ b/docs/contrib.rst
@@ -56,3 +56,9 @@ all the time.
 
 You may also use both of them. To use these checks add them to `INSTALLED_APPS` in your
 Django settings module.
+
+``cache``
+---------
+
+The key `djangohealtcheck_test` will be written to the cache backend to validate that the cache is working.  
+The name of the key can be customized by setting `HEALTHCHECK_CACHE_KEY` to another value.

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -71,7 +71,7 @@ exceeds 90% or available memory drops below 100 MB.
    memory falls below the specified value, a warning will be reported.
 
 Celery Health Check
-----------------------
+-------------------
 Using `django.settings` you may exert more fine-grained control over the behavior of the celery health check
 
 .. list-table:: Additional Settings
@@ -82,6 +82,10 @@ Using `django.settings` you may exert more fine-grained control over the behavio
      - Type
      - Default
      - Description
+   * - `HEALTHCHECK_CACHE_KEY`
+     - String
+     - djangohealtcheck_test
+     - Specifies the name of the key to write to and read from to validate that the cache is working.
    * - `HEALTHCHECK_CELERY_QUEUE_TIMEOUT`
      - Number
      - 3

--- a/health_check/cache/backends.py
+++ b/health_check/cache/backends.py
@@ -1,13 +1,15 @@
 from django.core.cache import CacheKeyWarning, caches
+from django.conf import settings
 
 from health_check.backends import BaseHealthCheckBackend
 from health_check.exceptions import ServiceReturnedUnexpectedResult, ServiceUnavailable
 
-
 class CacheBackend(BaseHealthCheckBackend):
+
     def __init__(self, backend="default"):
         super().__init__()
         self.backend = backend
+        self.cache_key = getattr(settings, "HEALTHCHECK_CACHE_KEY", "djangohealtcheck_test")
 
     def identifier(self):
         return f"Cache backend: {self.backend}"
@@ -16,9 +18,9 @@ class CacheBackend(BaseHealthCheckBackend):
         cache = caches[self.backend]
 
         try:
-            cache.set("djangohealtcheck_test", "itworks")
-            if not cache.get("djangohealtcheck_test") == "itworks":
-                raise ServiceUnavailable("Cache key does not match")
+            cache.set(self.cache_key, "itworks")
+            if not cache.get(self.cache_key) == "itworks":
+                raise ServiceUnavailable(f"Cache key {self.cache_key} does not match")
         except CacheKeyWarning as e:
             self.add_error(ServiceReturnedUnexpectedResult("Cache key warning"), e)
         except ValueError as e:


### PR DESCRIPTION
Using a static class variable allows applications using django-health-check as a 3rd-party package to read the key's identifier used to read/write the cache entry.

This is in particular useful, if the application needs to know which keys are written from other packages and are not part of the application logic itself.