### PR TITLE
Catch Redis exceptions while checking cache backend

### DIFF
--- a/health_check/cache/backends.py
+++ b/health_check/cache/backends.py
@@ -4,6 +4,19 @@ from health_check.backends import BaseHealthCheckBackend
 from health_check.exceptions import ServiceReturnedUnexpectedResult, ServiceUnavailable
 
 
+try:
+    # Exceptions thrown by Redis do not subclass builtin exceptions like ConnectionError.
+    # Additionally, not only connection errors (ConnectionError -> RedisError) can be raised,
+    # but also errors for time-outs (TimeoutError -> RedisError)
+    # and if the backend is read-only (ReadOnlyError -> ResponseError -> RedisError).
+    # Since we know what we are trying to do here, we are not picky and catch the global exception RedisError.
+    from redis.exceptions import RedisError
+except ModuleNotFoundError:
+    # In case Redis is not installed and another cache backend is used.
+    class RedisError(Exception):
+        pass
+
+
 class CacheBackend(BaseHealthCheckBackend):
     def __init__(self, backend="default"):
         super().__init__()
@@ -23,5 +36,5 @@ class CacheBackend(BaseHealthCheckBackend):
             self.add_error(ServiceReturnedUnexpectedResult("Cache key warning"), e)
         except ValueError as e:
             self.add_error(ServiceReturnedUnexpectedResult("ValueError"), e)
-        except ConnectionError as e:
+        except (ConnectionError, RedisError) as e:
             self.add_error(ServiceReturnedUnexpectedResult("Connection Error"), e)


### PR DESCRIPTION
Exceptions thrown by Redis do not subclass builtin exceptions like ConnectionError. Prior to this commit such exceptions would not be catched while running the health-check on redis-backed cache backends.

Closes #341 