### PR TITLE
Respect celery configuration namespace

### DIFF
--- a/health_check/contrib/rabbitmq/backends.py
+++ b/health_check/contrib/rabbitmq/backends.py
@@ -13,11 +13,14 @@ logger = logging.getLogger(__name__)
 class RabbitMQHealthCheck(BaseHealthCheckBackend):
     """Health check for RabbitMQ."""
 
+    namespace = None
+
     def check_status(self):
         """Check RabbitMQ service by opening and closing a broker channel."""
         logger.debug("Checking for a broker_url on django settings...")
 
-        broker_url = getattr(settings, "BROKER_URL", None)
+        broker_url_setting_key = f"{self.namespace}_BROKER_URL" if self.namespace else "BROKER_URL"
+        broker_url = getattr(settings, broker_url_setting_key, None)
 
         logger.debug("Got %s as the broker_url. Connecting to rabbit...", broker_url)
 


### PR DESCRIPTION
When configuring Celery with RabbitMQ in Django, one often uses `app.config_from_object('django.conf:settings', namespace='CELERY')` as per the Celery Quick Start (https://docs.celeryq.dev/en/stable/django/first-steps-with-django.html). This requires that all configuration keys in the Django settings have to be prefixed with `CELERY_`.

The previous implementation only used `settings.BROKER_URL` (which may be `None`). When passing `None` to Celery (or more specifically: the `Connection` object), it would default to `localhost`. Expand the `RabbitMQHealthCheck` to accept a `namespace` attribute which can be set to `CELERY` for example.