### PR TITLE
Streamline quotes in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,21 +101,21 @@ To use the RabbitMQ healthcheck, please make sure that there is a variable named
 rabbit server. For example:
 
 ```python
-    BROKER_URL = amqp://myuser:mypassword@localhost:5672/myvhost
+    BROKER_URL = "amqp://myuser:mypassword@localhost:5672/myvhost"
 ```
 
 To use the Redis healthcheck, please make sure that there is a variable named ``REDIS_URL``
 on django.conf.settings with the required format to connect to your redis server. For example:
 
 ```python
-    REDIS_URL = redis://localhost:6370
+    REDIS_URL = "redis://localhost:6370"
 ```
 
 The cache healthcheck tries to write and read a specific key within the cache backend.
 It can be customized by setting `HEALTHCHECK_CACHE_KEY` to another value:
 
 ```python
-    HEALTHCHECK_CACHE_KEY = custom_healthcheck_key
+    HEALTHCHECK_CACHE_KEY = "custom_healthcheck_key"
 ```
 
 ## Setting up monitoring

--- a/docs/contrib.rst
+++ b/docs/contrib.rst
@@ -1,19 +1,19 @@
 contrib
 =======
 
-``psutil``
-----------
+`psutil`
+--------
 
 Full disks and out-of-memory conditions are common causes of service outages.
 These situations can be averted by checking disk and memory utilization via the
-``psutil`` package:
+`psutil` package:
 
 .. code::
 
     pip install psutil
 
 Once that dependency has been installed, make sure that the corresponding Django
-app has been added to ``INSTALLED_APPS``:
+app has been added to `INSTALLED_APPS`:
 
 .. code:: python
 
@@ -36,8 +36,8 @@ to disable any of these checks, set its value to ``None``.
         'MEMORY_MIN' = 100,    # in MB
     }
 
-``celery``
-----------
+`celery`
+--------
 
 If you are using Celery you may choose between two different Celery checks.
 
@@ -57,8 +57,8 @@ all the time.
 You may also use both of them. To use these checks add them to `INSTALLED_APPS` in your
 Django settings module.
 
-``cache``
----------
+`cache`
+-------
 
 The key `djangohealtcheck_test` will be written to the cache backend to validate that the cache is working.  
 The name of the key can be customized by setting `HEALTHCHECK_CACHE_KEY` to another value.

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -1,13 +1,13 @@
 Settings
 ========
 
-Settings can be configured via the ``HEALTH_CHECK`` dictionary.
+Settings can be configured via the `HEALTH_CHECK` dictionary.
 
 .. data:: WARNINGS_AS_ERRORS
 
     Treats :class:`ServiceWarning` as errors, meaning they will cause the views
-    to respond with a 500 status code. Default is ``True``. If set to
-    ``False`` warnings will be displayed in the template on in the JSON
+    to respond with a 500 status code. Default is `True`. If set to
+    `False` warnings will be displayed in the template on in the JSON
     response but the status code will remain a 200.
 
 Security
@@ -42,13 +42,13 @@ You can still use any uptime bot that is URL based while enjoying token protecti
     Do NOT use Django's `SECRET_KEY` setting. This should never be exposed,
     to any third party. Not even your trusted uptime bot.
 
-``psutil``
-----------
+`psutil`
+--------
 
 The following default settings will be used to check for disk and memory
 utilization. If you would prefer different thresholds, you can add the dictionary
 below to your Django settings file and adjust the values accordingly. If you want
-to disable any of these checks, set its value to ``None``.
+to disable any of these checks, set its value to `None`.
 
 .. code:: python
 
@@ -72,6 +72,7 @@ exceeds 90% or available memory drops below 100 MB.
 
 Celery Health Check
 -------------------
+
 Using `django.settings` you may exert more fine-grained control over the behavior of the celery health check
 
 .. list-table:: Additional Settings
@@ -84,13 +85,13 @@ Using `django.settings` you may exert more fine-grained control over the behavio
      - Description
    * - `HEALTHCHECK_CACHE_KEY`
      - String
-     - djangohealtcheck_test
+     - `djangohealtcheck_test`
      - Specifies the name of the key to write to and read from to validate that the cache is working.
    * - `HEALTHCHECK_CELERY_QUEUE_TIMEOUT`
      - Number
-     - 3
+     - `3`
      - Specifies the maximum amount of time a task may spend in the queue before being automatically revoked with a `TaskRevokedError`.
    * - `HEALTHCHECK_CELERY_RESULT_TIMEOUT`
      - Number
-     - 3
+     - `3`
      - Specifies the maximum total time for a task to complete and return a result, including queue time.


### PR DESCRIPTION
This is a follow-up from #336.
This PR streamlines and corrects quotes around strings and inline code.