### PR TITLE
:gear: Adds Django 4.2 support and fixes trove classifiers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.x"
+          cache: 'pip'
       - run: python -m pip install --upgrade pip build wheel twine
       - run: python -m build --sdist --wheel
       - run: python -m twine check dist/*
@@ -49,6 +50,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.10"
+          cache: 'pip'
       - run: python -m pip install -e .[docs]
       - run: python -m sphinx -b html -W docs docs/_build
 
@@ -74,6 +76,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
       - run: python -m pip install .[test]
       - run: python -m pip install Django~="${{ matrix.django-version }}.0"
       - run: python -m pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,6 @@ jobs:
         django-version:
           - "2.2"
           - "3.2"
-          - "4.0"
           - "4.1"
           - "4.2"
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
         with:
           python-version: "3.x"
           cache: 'pip'
+          cache-dependency-path: '**/pyproject.toml'
       - run: python -m pip install --upgrade pip build wheel twine
       - run: python -m build --sdist --wheel
       - run: python -m twine check dist/*
@@ -51,6 +52,7 @@ jobs:
         with:
           python-version: "3.10"
           cache: 'pip'
+          cache-dependency-path: '**/pyproject.toml'
       - run: python -m pip install -e .[docs]
       - run: python -m sphinx -b html -W docs docs/_build
 
@@ -76,6 +78,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
+          cache-dependency-path: '**/pyproject.toml'
       - run: python -m pip install .[test]
       - run: python -m pip install Django~="${{ matrix.django-version }}.0"
       - run: python -m pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,7 @@ jobs:
           - "3.2"
           - "4.0"
           - "4.1"
+          - "4.2"
     steps:
       - uses: actions/checkout@v3
       - name: Setup Python version ${{ matrix.python-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,6 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: "3.x"
-          cache: 'pip'
     - run: python -m pip install --upgrade pip build wheel twine
     - run: python -m build --sdist --wheel
     - run: python -m twine upload dist/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: "3.x"
+          cache: 'pip'
     - run: python -m pip install --upgrade pip build wheel twine
     - run: python -m build --sdist --wheel
     - run: python -m twine upload dist/*

--- a/docs/readme.rst
+++ b/docs/readme.rst
@@ -1,1 +1,291 @@
-.. include:: ../README.rst
+django-health-check
+===================
+
+|version| |pyversion| |djversion| |license|
+
+This project checks for various conditions and provides reports when
+anomalous behavior is detected.
+
+The following health checks are bundled with this project:
+
+-  cache
+-  database
+-  storage
+-  disk and memory utilization (via ``psutil``)
+-  AWS S3 storage
+-  Celery task queue
+-  Celery ping
+-  RabbitMQ
+-  Migrations
+
+Writing your own custom health checks is also very quick and easy.
+
+We also like contributions, so don’t be afraid to make a pull request.
+
+Use Cases
+---------
+
+The primary intended use case is to monitor conditions via HTTP(S), with
+responses available in HTML and JSON formats. When you get back a
+response that includes one or more problems, you can then decide the
+appropriate course of action, which could include generating
+notifications and/or automating the replacement of a failing node with a
+new one. If you are monitoring health in a high-availability environment
+with a load balancer that returns responses from multiple nodes, please
+note that certain checks (e.g., disk and memory usage) will return
+responses specific to the node selected by the load balancer.
+
+Supported Versions
+------------------
+
+We officially only support the latest version of Python as well as the
+latest version of Django and the latest Django LTS version.
+
+Installation
+------------
+
+First, install the ``django-health-check`` package:
+
+.. code:: shell
+
+   $ pip install django-health-check
+
+Add the health checker to a URL you want to use:
+
+.. code:: python
+
+       urlpatterns = [
+           # ...
+           url(r'^ht/', include('health_check.urls')),
+       ]
+
+Add the ``health_check`` applications to your ``INSTALLED_APPS``:
+
+.. code:: python
+
+       INSTALLED_APPS = [
+           # ...
+           'health_check',                             # required
+           'health_check.db',                          # stock Django health checkers
+           'health_check.cache',
+           'health_check.storage',
+           'health_check.contrib.migrations',
+           'health_check.contrib.celery',              # requires celery
+           'health_check.contrib.celery_ping',         # requires celery
+           'health_check.contrib.psutil',              # disk and memory utilization; requires psutil
+           'health_check.contrib.s3boto3_storage',     # requires boto3 and S3BotoStorage backend
+           'health_check.contrib.rabbitmq',            # requires RabbitMQ broker
+           'health_check.contrib.redis',               # requires Redis broker
+       ]
+
+**Note:** If using ``boto 2.x.x`` use
+``health_check.contrib.s3boto_storage``
+
+(Optional) If using the ``psutil`` app, you can configure disk and
+memory threshold settings; otherwise below defaults are assumed. If you
+want to disable one of these checks, set its value to ``None``.
+
+.. code:: python
+
+       HEALTH_CHECK = {
+           'DISK_USAGE_MAX': 90,  # percent
+           'MEMORY_MIN': 100,    # in MB
+       }
+
+If using the DB check, run migrations:
+
+.. code:: shell
+
+   $ django-admin migrate
+
+To use the RabbitMQ healthcheck, please make sure that there is a
+variable named ``BROKER_URL`` on django.conf.settings with the required
+format to connect to your rabbit server. For example:
+
+.. code:: python
+
+       BROKER_URL = "amqp://myuser:mypassword@localhost:5672/myvhost"
+
+To use the Redis healthcheck, please make sure that there is a variable
+named ``REDIS_URL`` on django.conf.settings with the required format to
+connect to your redis server. For example:
+
+.. code:: python
+
+       REDIS_URL = "redis://localhost:6370"
+
+The cache healthcheck tries to write and read a specific key within the
+cache backend. It can be customized by setting ``HEALTHCHECK_CACHE_KEY``
+to another value:
+
+.. code:: python
+
+       HEALTHCHECK_CACHE_KEY = "custom_healthcheck_key"
+
+Setting up monitoring
+---------------------
+
+You can use tools like Pingdom, StatusCake or other uptime robots to
+monitor service status. The ``/ht/`` endpoint will respond with an HTTP
+200 if all checks passed and with an HTTP 500 if any of the tests
+failed. Getting machine-readable JSON reports
+
+If you want machine-readable status reports you can request the ``/ht/``
+endpoint with the ``Accept`` HTTP header set to ``application/json`` or
+pass ``format=json`` as a query parameter.
+
+The backend will return a JSON response:
+
+.. code:: shell
+
+       $ curl -v -X GET -H "Accept: application/json" http://www.example.com/ht/
+
+       > GET /ht/ HTTP/1.1
+       > Host: www.example.com
+       > Accept: application/json
+       >
+       < HTTP/1.1 200 OK
+       < Content-Type: application/json
+
+       {
+           "CacheBackend": "working",
+           "DatabaseBackend": "working",
+           "S3BotoStorageHealthCheck": "working"
+       }
+
+       $ curl -v -X GET http://www.example.com/ht/?format=json
+
+       > GET /ht/?format=json HTTP/1.1
+       > Host: www.example.com
+       >
+       < HTTP/1.1 200 OK
+       < Content-Type: application/json
+
+       {
+           "CacheBackend": "working",
+           "DatabaseBackend": "working",
+           "S3BotoStorageHealthCheck": "working"
+       }
+
+Writing a custom health check
+-----------------------------
+
+Writing a health check is quick and easy:
+
+.. code:: python
+
+       from health_check.backends import BaseHealthCheckBackend
+
+       class MyHealthCheckBackend(BaseHealthCheckBackend):
+           #: The status endpoints will respond with a 200 status code
+           #: even if the check errors.
+           critical_service = False
+
+           def check_status(self):
+               # The test code goes here.
+               # You can use `self.add_error` or
+               # raise a `HealthCheckException`,
+               # similar to Django's form validation.
+               pass
+
+           def identifier(self):
+               return self.__class__.__name__  # Display name on the endpoint.
+
+After writing a custom checker, register it in your app configuration:
+
+.. code:: python
+
+       from django.apps import AppConfig
+
+       from health_check.plugins import plugin_dir
+
+       class MyAppConfig(AppConfig):
+           name = 'my_app'
+
+           def ready(self):
+               from .backends import MyHealthCheckBackend
+               plugin_dir.register(MyHealthCheckBackend)
+
+Make sure the application you write the checker into is registered in
+your ``INSTALLED_APPS``.
+
+Customizing output
+------------------
+
+You can customize HTML or JSON rendering by inheriting from ``MainView``
+in ``health_check.views`` and customizing the ``template_name``,
+``get``, ``render_to_response`` and ``render_to_response_json``
+properties:
+
+.. code:: python
+
+       # views.py
+       from health_check.views import MainView
+
+       class HealthCheckCustomView(MainView):
+           template_name = 'myapp/health_check_dashboard.html'  # customize the used templates
+
+           def get(self, request, *args, **kwargs):
+               plugins = []
+               status = 200 # needs to be filled status you need
+               # ...
+               if 'application/json' in request.META.get('HTTP_ACCEPT', ''):
+                   return self.render_to_response_json(plugins, status)
+               return self.render_to_response(plugins, status)
+
+           def render_to_response(self, plugins, status):       # customize HTML output
+               return HttpResponse('COOL' if status == 200 else 'SWEATY', status=status)
+
+           def render_to_response_json(self, plugins, status):  # customize JSON output
+               return JsonResponse(
+                   {str(p.identifier()): 'COOL' if status == 200 else 'SWEATY' for p in plugins},
+                   status=status
+               )
+
+       # urls.py
+       import views
+
+       urlpatterns = [
+           # ...
+           url(r'^ht/$', views.HealthCheckCustomView.as_view(), name='health_check_custom'),
+       ]
+
+Django command
+--------------
+
+You can run the Django command ``health_check`` to perform your health
+checks via the command line, or periodically with a cron, as follow:
+
+.. code:: shell
+
+       django-admin health_check
+
+This should yield the following output:
+
+::
+
+       DatabaseHealthCheck      ... working
+       CustomHealthCheck        ... unavailable: Something went wrong!
+
+Similar to the http version, a critical error will cause the command to
+quit with the exit code ``1``.
+
+Other resources
+---------------
+
+-  `django-watchman <https://github.com/mwarkentin/django-watchman>`__
+   is a package that does some of the same things in a slightly
+   different way.
+-  See this
+   `weblog <https://www.vincit.fi/en/blog/deploying-django-to-elastic-beanstalk-with-https-redirects-and-functional-health-checks/>`__
+   about configuring Django and health checking with AWS Elastic Load
+   Balancer.
+
+.. |version| image:: https://img.shields.io/pypi/v/django-health-check.svg
+   :target: https://pypi.python.org/pypi/django-health-check/
+.. |pyversion| image:: https://img.shields.io/pypi/pyversions/django-health-check.svg
+   :target: https://pypi.python.org/pypi/django-health-check/
+.. |djversion| image:: https://img.shields.io/pypi/djversions/django-health-check.svg
+   :target: https://pypi.python.org/pypi/django-health-check/
+.. |license| image:: https://img.shields.io/badge/license-MIT-blue.svg
+   :target: https://pypi.python.org/pypi/django-health-check/

--- a/health_check/cache/backends.py
+++ b/health_check/cache/backends.py
@@ -4,7 +4,6 @@ from django.core.cache import CacheKeyWarning, caches
 from health_check.backends import BaseHealthCheckBackend
 from health_check.exceptions import ServiceReturnedUnexpectedResult, ServiceUnavailable
 
-
 try:
     # Exceptions thrown by Redis do not subclass builtin exceptions like ConnectionError.
     # Additionally, not only connection errors (ConnectionError -> RedisError) can be raised,

--- a/health_check/cache/backends.py
+++ b/health_check/cache/backends.py
@@ -1,5 +1,5 @@
-from django.core.cache import CacheKeyWarning, caches
 from django.conf import settings
+from django.core.cache import CacheKeyWarning, caches
 
 from health_check.backends import BaseHealthCheckBackend
 from health_check.exceptions import ServiceReturnedUnexpectedResult, ServiceUnavailable

--- a/health_check/contrib/rabbitmq/backends.py
+++ b/health_check/contrib/rabbitmq/backends.py
@@ -19,7 +19,9 @@ class RabbitMQHealthCheck(BaseHealthCheckBackend):
         """Check RabbitMQ service by opening and closing a broker channel."""
         logger.debug("Checking for a broker_url on django settings...")
 
-        broker_url_setting_key = f"{self.namespace}_BROKER_URL" if self.namespace else "BROKER_URL"
+        broker_url_setting_key = (
+            f"{self.namespace}_BROKER_URL" if self.namespace else "BROKER_URL"
+        )
         broker_url = getattr(settings, broker_url_setting_key, None)
 
         logger.debug("Got %s as the broker_url. Connecting to rabbit...", broker_url)

--- a/health_check/db/migrations/0001_initial.py
+++ b/health_check/db/migrations/0001_initial.py
@@ -5,7 +5,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     replaces = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,9 @@
+[tool.black]
+target-version = ["py38"]
+
+[tool.pytest.ini_options]
+addopts = "--nomigrations --reuse-db --strict-markers"
+DJANGO_SETTINGS_MODULE = "tests.testapp.settings"
+norecursedirs = ".git"
+python_files = "test_*.py"
+xfail_strict = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ classifier =
   Framework :: Django :: 3.2
   Framework :: Django :: 4.0
   Framework :: Django :: 4.1
+  Framework :: Django :: 4.2
   Intended Audience :: Developers
   License :: OSI Approved :: MIT License
   Operating System :: OS Independent
@@ -27,10 +28,6 @@ classifier =
   Programming Language :: Python :: 3.10
   Programming Language :: Python :: 3.11
   Topic :: Software Development :: Quality Assurance
-  Framework :: Django
-  Framework :: Django :: 2.2
-  Framework :: Django :: 4.0
-  Framework :: Django :: 4.1
   Topic :: System :: Logging
   Topic :: System :: Monitoring
   Topic :: Utilities

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -71,9 +71,7 @@ class HealthCheckCacheTests(TestCase):
         cache_backend = CacheBackend("broken")
         cache_backend.run_check()
         self.assertTrue(cache_backend.errors)
-        self.assertIn(
-            "unavailable: Cache key does not match", cache_backend.pretty_status()
-        )
+        self.assertIn("does not match", cache_backend.pretty_status())
 
     # check_status should raise ServiceUnavailable when values at cache key do not match
     @patch(
@@ -83,9 +81,7 @@ class HealthCheckCacheTests(TestCase):
         cache_backend = CacheBackend()
         cache_backend.run_check()
         self.assertTrue(cache_backend.errors)
-        self.assertIn(
-            "unavailable: Cache key does not match", cache_backend.pretty_status()
-        )
+        self.assertIn("does not match", cache_backend.pretty_status())
 
     # check_status should catch generic exceptions raised by set and convert to ServiceUnavailable
     @patch(


### PR DESCRIPTION
This just checks a few boxes to get trove classifiers and CI testing... 

I'm seeing a few warnings, but things are passing now (some of the `RemovedInDjango51Warning` might require dropping 2.2 support): 

```
../../lib/python3.10/site-packages/kombu/utils/compat.py:82
tests/test_celery_ping.py::TestCeleryPingHealthCheck::test_check_status_doesnt_add_errors_when_ping_successful
  /Users/jefftriplett/.virtualenvs/django-health-check/lib/python3.10/site-packages/kombu/utils/compat.py:82: DeprecationWarning: SelectableGroups dict interface is deprecated. Use select.
    for ep in importlib_metadata.entry_points().get(namespace, [])

../../lib/python3.10/site-packages/django/conf/__init__.py:193
  /Users/jefftriplett/.virtualenvs/django-health-check/lib/python3.10/site-packages/django/conf/__init__.py:193: RemovedInDjango51Warning: The DEFAULT_FILE_STORAGE setting is deprecated. Use STORAGES instead.
    self._show_deprecation_warning(

tests/test_storage.py::HealthCheckStorageTests::test_get_storage
  /Users/jefftriplett/.virtualenvs/django-health-check/lib/python3.10/site-packages/django/core/files/storage/__init__.py:32: RemovedInDjango51Warning: django.core.files.storage.get_storage_class is deprecated in favor of using django.core.files.storage.storages.
    warnings.warn(GET_STORAGE_CLASS_DEPRECATED_MSG, RemovedInDjango51Warning)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```
