### PR TITLE
refactor(django50): replace DEFAULT_FILE_STORAGE wiht STORAGES setting

### DIFF
--- a/health_check/storage/backends.py
+++ b/health_check/storage/backends.py
@@ -68,4 +68,4 @@ class StorageHealthCheck(BaseHealthCheckBackend):
 
 
 class DefaultFileStorageHealthCheck(StorageHealthCheck):
-    storage = settings.DEFAULT_FILE_STORAGE
+    storage = settings.STORAGES["default"]["BACKEND"]


### PR DESCRIPTION
RemovedInDjango51Warning: The DEFAULT_FILE_STORAGE setting is deprecated. Use STORAGES instead.