### PR TITLE
Allow selecting which celery worker(s) to ping

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -117,3 +117,26 @@ Using `django.settings` you may exert more fine-grained control over the behavio
      - Number
      - `None`
      - Specifies the healthcheck task priority.
+
+
+Celery-Ping Health Check
+------------------------
+
+Using `django.settings` you may exert more fine-grained control over the behavior of the celery-ping health check
+
+.. list-table:: Additional Settings
+   :widths: 25 10 10 55
+   :header-rows: 1
+
+   * - Name
+     - Type
+     - Default
+     - Description
+   * - `HEALTHCHECK_CELERY_PING_TIMEOUT`
+     - Number
+     - `1`
+     - Specifies the maximum total time (in seconds) for which "pong" responses are awaited.
+   * - `HEALTHCHECK_CELERY_PING_DESTINATION`
+     - List of Strings
+     - `None`
+     - Specifies the list of workers which will receive the "ping" request.

--- a/tests/test_celery_ping.py
+++ b/tests/test_celery_ping.py
@@ -148,10 +148,18 @@ class TestCeleryPingHealthCheck:
                 {"celery2@4cc150a7b49b": CeleryPingHealthCheck.CORRECT_PING_RESPONSE},
                 {"celery3@4cc150a7b49b": CeleryPingHealthCheck.CORRECT_PING_RESPONSE},
             ],
+        ), patch(
+            self.CELERY_APP_CONTROL_INSPECT_ACTIVE_QUEUES,
+            return_value={
+                celery_worker: [
+                    {"name": queue.name} for queue in settings.CELERY_QUEUES
+                ]
+                for celery_worker in ("celery1@4cc150a7b49b", "celery2@4cc150a7b49b", "celery3@4cc150a7b49b")
+            },
         ):
             health_check.check_status()
 
-            assert len(health_check.errors) == 1
+            assert not health_check.errors
 
 
 class TestCeleryPingHealthCheckApps:


### PR DESCRIPTION
This PR aims to add the ability to select which celery worker needs to be ping-ed.

The main use case is to use the management command to check a specific worker, thus the check should be ok only if _that_ worker is up&running. Since celery [`app.control.ping`](https://docs.celeryq.dev/en/stable/reference/celery.app.control.html#celery.app.control.Control.ping) allows a list as parameter the settings allows a list too. By default it was kept `None` since it means "ping every worker", which is the current behaviour.