### PR TITLE
Respect celery 4+ configuration names

### DIFF
--- a/health_check/contrib/celery_ping/backends.py
+++ b/health_check/contrib/celery_ping/backends.py
@@ -50,7 +50,12 @@ class CeleryPingHealthCheck(BaseHealthCheckBackend):
             self._check_active_queues(active_workers)
 
     def _check_active_queues(self, active_workers):
-        defined_queues = app.conf.CELERY_QUEUES
+        try:
+            # Celery 4+
+            defined_queues = app.conf.task_queues
+        except AttributeError:
+            # Celery <4
+            defined_queues = app.conf.CELERY_QUEUES
 
         if not defined_queues:
             return


### PR DESCRIPTION
Since celery 4.0, configuration settings names should be lowercase.  
Moreover the celery prefix is removed and tasks related settings are prefixed with `task_`

To ensure backward compatibility with celery 3, it checks first for the up to date settings naming and fallback with the current behavior.