### PR TITLE
Correct default file storage for Django 4.2

### DIFF
--- a/health_check/storage/backends.py
+++ b/health_check/storage/backends.py
@@ -2,7 +2,7 @@ import uuid
 
 from django.conf import settings
 from django.core.files.base import ContentFile
-from django.core.files.storage import get_storage_class
+from django.core.files.storage import get_storage_class, default_storage
 
 from health_check.backends import BaseHealthCheckBackend
 from health_check.exceptions import ServiceUnavailable
@@ -68,4 +68,4 @@ class StorageHealthCheck(BaseHealthCheckBackend):
 
 
 class DefaultFileStorageHealthCheck(StorageHealthCheck):
-    storage = settings.DEFAULT_FILE_STORAGE
+    storage = default_storage


### PR DESCRIPTION
This is now the correct method to get the default storage and ensures that https://code.djangoproject.com/ticket/34773 that was fixed in Django 4.2.5 doesn't cause problems with this check. Cheers :beers: