### PR TITLE
Quieten deprecation warning

### DIFF
--- a/health_check/storage/backends.py
+++ b/health_check/storage/backends.py
@@ -81,4 +81,4 @@ class StorageHealthCheck(BaseHealthCheckBackend):
 
 class DefaultFileStorageHealthCheck(StorageHealthCheck):
     storage_alias = "default"
-    storage = settings.DEFAULT_FILE_STORAGE
+    storage = settings.DEFAULT_FILE_STORAGE if django.VERSION < (4, 2) else None


### PR DESCRIPTION
DEFAULT_FILE_STORAGE isn't actually used here if the version is >=4.2, and it's triggering a deprecation warning -- this PR quietens that warning.
```pytb
Traceback (most recent call last):
  File "/Users/scottgigante/envs/django/bin/py.test", line 8, in <module>
    sys.exit(console_main())
             ^^^^^^^^^^^^^^
  File "/Users/scottgigante/envs/django/lib/python3.11/site-packages/_pytest/config/__init__.py", line 189, in console_main
    code = main()
           ^^^^^^
  File "/Users/scottgigante/envs/django/lib/python3.11/site-packages/_pytest/config/__init__.py", line 147, in main
    config = _prepareconfig(args, plugins)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/scottgigante/envs/django/lib/python3.11/site-packages/_pytest/config/__init__.py", line 328, in _prepareconfig
    config = pluginmanager.hook.pytest_cmdline_parse(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/scottgigante/envs/django/lib/python3.11/site-packages/pluggy/_hooks.py", line 433, in __call__
    return self._hookexec(self.name, self._hookimpls, kwargs, firstresult)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/scottgigante/envs/django/lib/python3.11/site-packages/pluggy/_manager.py", line 112, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/scottgigante/envs/django/lib/python3.11/site-packages/pluggy/_callers.py", line 133, in _multicall
    teardown[0].send(outcome)
  File "/Users/scottgigante/envs/django/lib/python3.11/site-packages/_pytest/helpconfig.py", line 103, in pytest_cmdline_parse
    config: Config = outcome.get_result()
                     ^^^^^^^^^^^^^^^^^^^^
  File "/Users/scottgigante/envs/django/lib/python3.11/site-packages/pluggy/_result.py", line 108, in get_result
    raise exc.with_traceback(exc.__traceback__)
  File "/Users/scottgigante/envs/django/lib/python3.11/site-packages/pluggy/_callers.py", line 80, in _multicall
    res = hook_impl.function(*args)
          ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/scottgigante/envs/django/lib/python3.11/site-packages/_pytest/config/__init__.py", line 1075, in pytest_cmdline_parse
    self.parse(args)
  File "/Users/scottgigante/envs/django/lib/python3.11/site-packages/_pytest/config/__init__.py", line 1425, in parse
    self._preparse(args, addopts=addopts)
  File "/Users/scottgigante/envs/django/lib/python3.11/site-packages/_pytest/config/__init__.py", line 1327, in _preparse
    self.hook.pytest_load_initial_conftests(
  File "/Users/scottgigante/envs/django/lib/python3.11/site-packages/pluggy/_hooks.py", line 433, in __call__
    return self._hookexec(self.name, self._hookimpls, kwargs, firstresult)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/scottgigante/envs/django/lib/python3.11/site-packages/pluggy/_manager.py", line 112, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/scottgigante/envs/django/lib/python3.11/site-packages/pluggy/_callers.py", line 155, in _multicall
    return outcome.get_result()
           ^^^^^^^^^^^^^^^^^^^^
  File "/Users/scottgigante/envs/django/lib/python3.11/site-packages/pluggy/_result.py", line 108, in get_result
    raise exc.with_traceback(exc.__traceback__)
  File "/Users/scottgigante/envs/django/lib/python3.11/site-packages/pluggy/_callers.py", line 80, in _multicall
    res = hook_impl.function(*args)
          ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/scottgigante/envs/django/lib/python3.11/site-packages/pytest_django/plugin.py", line 360, in pytest_load_initial_conftests
    _setup_django(early_config)
  File "/Users/scottgigante/envs/django/lib/python3.11/site-packages/pytest_django/plugin.py", line 236, in _setup_django
    django.setup()
  File "/Users/scottgigante/envs/django/lib/python3.11/site-packages/django/__init__.py", line 24, in setup
    apps.populate(settings.INSTALLED_APPS)
  File "/Users/scottgigante/envs/django/lib/python3.11/site-packages/django/apps/registry.py", line 124, in populate
    app_config.ready()
  File "/Users/scottgigante/envs/django/lib/python3.11/site-packages/health_check/storage/apps.py", line 10, in ready
    from .backends import DefaultFileStorageHealthCheck
  File "/Users/scottgigante/envs/django/lib/python3.11/site-packages/health_check/storage/backends.py", line 82, in <module>
    class DefaultFileStorageHealthCheck(StorageHealthCheck):
  File "/Users/scottgigante/envs/django/lib/python3.11/site-packages/health_check/storage/backends.py", line 84, in DefaultFileStorageHealthCheck
    storage = settings.DEFAULT_FILE_STORAGE
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/scottgigante/envs/django/lib/python3.11/site-packages/django/utils/functional.py", line 295, in __getattribute__
    value = super().__getattribute__(name)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/scottgigante/envs/django/lib/python3.11/site-packages/django/conf/__init__.py", line 193, in DEFAULT_FILE_STORAGE
    self._show_deprecation_warning(
  File "/Users/scottgigante/envs/django/lib/python3.11/site-packages/django/conf/__init__.py", line 174, in _show_deprecation_warning
    warnings.warn(message, category, stacklevel=2)
django.utils.deprecation.RemovedInDjango51Warning: The DEFAULT_FILE_STORAGE setting is deprecated. Use STORAGES instead.
```