### PR TITLE
Fix `The DEFAULT_FILE_STORAGE setting is deprecated` warning

### DIFF
--- a/health_check/storage/backends.py
+++ b/health_check/storage/backends.py
@@ -1,8 +1,8 @@
 import uuid
 
 import django
-from django.conf import settings
 from django.core.files.base import ContentFile
+from django.core.files.storage import default_storage
 
 if django.VERSION >= (4, 2):
     from django.core.files.storage import InvalidStorageError, storages
@@ -81,4 +81,4 @@ class StorageHealthCheck(BaseHealthCheckBackend):
 
 class DefaultFileStorageHealthCheck(StorageHealthCheck):
     storage_alias = "default"
-    storage = settings.DEFAULT_FILE_STORAGE
+    storage = default_storage


### PR DESCRIPTION
Split from: https://github.com/revsys/django-health-check/pull/397

There are already two PRs for this (https://github.com/revsys/django-health-check/pull/359, https://github.com/revsys/django-health-check/pull/383) but as they are conflicting with master right now I included it here to avoid the anoying warnings.

Closes https://github.com/revsys/django-health-check/pull/359, closes https://github.com/revsys/django-health-check/pull/383, fixes https://github.com/revsys/django-health-check/issues/366