### PR TITLE
Fix compatibility with pre-3.18 custom check backends

### DIFF
--- a/health_check/backends.py
+++ b/health_check/backends.py
@@ -20,14 +20,14 @@ class BaseHealthCheckBackend:
     def __init__(self):
         self.errors = []
 
-    def check_status(self, subset=None):
+    def check_status(self):
         raise NotImplementedError
 
-    def run_check(self, subset=None):
+    def run_check(self):
         start = timer()
         self.errors = []
         try:
-            self.check_status(subset=subset)
+            self.check_status()
         except HealthCheckException as e:
             self.add_error(e, e)
         except BaseException:

--- a/health_check/cache/backends.py
+++ b/health_check/cache/backends.py
@@ -28,7 +28,7 @@ class CacheBackend(BaseHealthCheckBackend):
     def identifier(self):
         return f"Cache backend: {self.backend}"
 
-    def check_status(self, subset=None):
+    def check_status(self):
         cache = caches[self.backend]
 
         try:

--- a/health_check/contrib/celery/backends.py
+++ b/health_check/contrib/celery/backends.py
@@ -8,7 +8,7 @@ from .tasks import add
 
 
 class CeleryHealthCheck(BaseHealthCheckBackend):
-    def check_status(self, subset=None):
+    def check_status(self):
         timeout = getattr(settings, "HEALTHCHECK_CELERY_TIMEOUT", 3)
         result_timeout = getattr(settings, "HEALTHCHECK_CELERY_RESULT_TIMEOUT", timeout)
         queue_timeout = getattr(settings, "HEALTHCHECK_CELERY_QUEUE_TIMEOUT", timeout)

--- a/health_check/contrib/celery_ping/backends.py
+++ b/health_check/contrib/celery_ping/backends.py
@@ -8,7 +8,7 @@ from health_check.exceptions import ServiceUnavailable
 class CeleryPingHealthCheck(BaseHealthCheckBackend):
     CORRECT_PING_RESPONSE = {"ok": "pong"}
 
-    def check_status(self, subset=None):
+    def check_status(self):
         timeout = getattr(settings, "HEALTHCHECK_CELERY_PING_TIMEOUT", 1)
 
         try:

--- a/health_check/contrib/migrations/backends.py
+++ b/health_check/contrib/migrations/backends.py
@@ -14,7 +14,7 @@ class MigrationsHealthCheck(BaseHealthCheckBackend):
     def get_migration_plan(self, executor):
         return executor.migration_plan(executor.loader.graph.leaf_nodes())
 
-    def check_status(self, subset=None):
+    def check_status(self):
         db_alias = getattr(settings, "HEALTHCHECK_MIGRATIONS_DB", DEFAULT_DB_ALIAS)
         try:
             executor = MigrationExecutor(connections[db_alias])

--- a/health_check/contrib/psutil/backends.py
+++ b/health_check/contrib/psutil/backends.py
@@ -14,7 +14,7 @@ MEMORY_MIN = HEALTH_CHECK["MEMORY_MIN"]
 
 
 class DiskUsage(BaseHealthCheckBackend):
-    def check_status(self, subset=None):
+    def check_status(self):
         try:
             du = psutil.disk_usage("/")
             if DISK_USAGE_MAX and du.percent >= DISK_USAGE_MAX:
@@ -28,7 +28,7 @@ class DiskUsage(BaseHealthCheckBackend):
 
 
 class MemoryUsage(BaseHealthCheckBackend):
-    def check_status(self, subset=None):
+    def check_status(self):
         try:
             memory = psutil.virtual_memory()
             if MEMORY_MIN and memory.available < (MEMORY_MIN * 1024 * 1024):

--- a/health_check/contrib/rabbitmq/backends.py
+++ b/health_check/contrib/rabbitmq/backends.py
@@ -15,7 +15,7 @@ class RabbitMQHealthCheck(BaseHealthCheckBackend):
 
     namespace = None
 
-    def check_status(self, subset=None):
+    def check_status(self):
         """Check RabbitMQ service by opening and closing a broker channel."""
         logger.debug("Checking for a broker_url on django settings...")
 

--- a/health_check/contrib/redis/backends.py
+++ b/health_check/contrib/redis/backends.py
@@ -14,7 +14,7 @@ class RedisHealthCheck(BaseHealthCheckBackend):
 
     redis_url = getattr(settings, "REDIS_URL", "redis://localhost/1")
 
-    def check_status(self, subset=None):
+    def check_status(self):
         """Check Redis service by pinging the redis instance with a redis connection."""
         logger.debug("Got %s as the redis_url. Connecting to redis...", self.redis_url)
 

--- a/health_check/db/backends.py
+++ b/health_check/db/backends.py
@@ -7,7 +7,7 @@ from .models import TestModel
 
 
 class DatabaseBackend(BaseHealthCheckBackend):
-    def check_status(self, subset=None):
+    def check_status(self):
         try:
             obj = TestModel.objects.create(title="test")
             obj.title = "newtest"

--- a/health_check/storage/backends.py
+++ b/health_check/storage/backends.py
@@ -67,7 +67,7 @@ class StorageHealthCheck(BaseHealthCheckBackend):
         if storage.exists(file_name):
             raise ServiceUnavailable("File was not deleted")
 
-    def check_status(self, subset=None):
+    def check_status(self):
         try:
             # write the file to the storage backend
             file_name = self.get_file_name()

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -9,12 +9,12 @@ from health_check.plugins import plugin_dir
 
 
 class FailPlugin(BaseHealthCheckBackend):
-    def check_status(self, subset=None):
+    def check_status(self):
         self.add_error("Oops")
 
 
 class OkPlugin(BaseHealthCheckBackend):
-    def check_status(self, subset=None):
+    def check_status(self):
         pass
 
 

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -9,12 +9,12 @@ from health_check.plugins import plugin_dir
 
 
 class FailPlugin(BaseHealthCheckBackend):
-    def check_status(self, subset=None):
+    def check_status(self):
         self.add_error("Oops")
 
 
 class OkPlugin(BaseHealthCheckBackend):
-    def check_status(self, subset=None):
+    def check_status(self):
         pass
 
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -5,12 +5,12 @@ from health_check.plugins import plugin_dir
 
 
 class FakePlugin(BaseHealthCheckBackend):
-    def check_status(self, subset=None):
+    def check_status(self):
         pass
 
 
 class Plugin(BaseHealthCheckBackend):
-    def check_status(self, subset=None):
+    def check_status(self):
         pass
 
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -92,7 +92,7 @@ class TestMainView:
 
     def test_error(self, client):
         class MyBackend(BaseHealthCheckBackend):
-            def check_status(self, subset=None):
+            def check_status(self):
                 self.add_error("Super Fail!")
 
         plugin_dir.reset()
@@ -104,7 +104,7 @@ class TestMainView:
 
     def test_warning(self, client):
         class MyBackend(BaseHealthCheckBackend):
-            def check_status(self, subset=None):
+            def check_status(self):
                 raise ServiceWarning("so so")
 
         plugin_dir.reset()
@@ -124,7 +124,7 @@ class TestMainView:
         class MyBackend(BaseHealthCheckBackend):
             critical_service = False
 
-            def check_status(self, subset=None):
+            def check_status(self):
                 self.add_error("Super Fail!")
 
         plugin_dir.reset()
@@ -136,7 +136,7 @@ class TestMainView:
 
     def test_success_accept_json(self, client):
         class JSONSuccessBackend(BaseHealthCheckBackend):
-            def run_check(self, subset=None):
+            def run_check(self):
                 pass
 
         plugin_dir.reset()
@@ -147,7 +147,7 @@ class TestMainView:
 
     def test_success_prefer_json(self, client):
         class JSONSuccessBackend(BaseHealthCheckBackend):
-            def run_check(self, subset=None):
+            def run_check(self):
                 pass
 
         plugin_dir.reset()
@@ -160,7 +160,7 @@ class TestMainView:
 
     def test_success_accept_xhtml(self, client):
         class SuccessBackend(BaseHealthCheckBackend):
-            def run_check(self, subset=None):
+            def run_check(self):
                 pass
 
         plugin_dir.reset()
@@ -171,7 +171,7 @@ class TestMainView:
 
     def test_success_unsupported_accept(self, client):
         class SuccessBackend(BaseHealthCheckBackend):
-            def run_check(self, subset=None):
+            def run_check(self):
                 pass
 
         plugin_dir.reset()
@@ -186,7 +186,7 @@ class TestMainView:
 
     def test_success_unsupported_and_supported_accept(self, client):
         class SuccessBackend(BaseHealthCheckBackend):
-            def run_check(self, subset=None):
+            def run_check(self):
                 pass
 
         plugin_dir.reset()
@@ -199,7 +199,7 @@ class TestMainView:
 
     def test_success_accept_order(self, client):
         class JSONSuccessBackend(BaseHealthCheckBackend):
-            def run_check(self, subset=None):
+            def run_check(self):
                 pass
 
         plugin_dir.reset()
@@ -213,7 +213,7 @@ class TestMainView:
 
     def test_success_accept_order__reverse(self, client):
         class JSONSuccessBackend(BaseHealthCheckBackend):
-            def run_check(self, subset=None):
+            def run_check(self):
                 pass
 
         plugin_dir.reset()
@@ -227,7 +227,7 @@ class TestMainView:
 
     def test_format_override(self, client):
         class JSONSuccessBackend(BaseHealthCheckBackend):
-            def run_check(self, subset=None):
+            def run_check(self):
                 pass
 
         plugin_dir.reset()
@@ -238,7 +238,7 @@ class TestMainView:
 
     def test_format_no_accept_header(self, client):
         class JSONSuccessBackend(BaseHealthCheckBackend):
-            def run_check(self, subset=None):
+            def run_check(self):
                 pass
 
         plugin_dir.reset()
@@ -249,7 +249,7 @@ class TestMainView:
 
     def test_error_accept_json(self, client):
         class JSONErrorBackend(BaseHealthCheckBackend):
-            def run_check(self, subset=None):
+            def run_check(self):
                 self.add_error("JSON Error")
 
         plugin_dir.reset()
@@ -266,7 +266,7 @@ class TestMainView:
 
     def test_success_param_json(self, client):
         class JSONSuccessBackend(BaseHealthCheckBackend):
-            def run_check(self, subset=None):
+            def run_check(self):
                 pass
 
         plugin_dir.reset()
@@ -280,11 +280,11 @@ class TestMainView:
 
     def test_success_subset_define(self, client):
         class SuccessOneBackend(BaseHealthCheckBackend):
-            def run_check(self, subset=None):
+            def run_check(self):
                 pass
 
         class SuccessTwoBackend(BaseHealthCheckBackend):
-            def run_check(self, subset=None):
+            def run_check(self):
                 pass
 
         plugin_dir.reset()
@@ -328,7 +328,7 @@ class TestMainView:
 
     def test_error_param_json(self, client):
         class JSONErrorBackend(BaseHealthCheckBackend):
-            def run_check(self, subset=None):
+            def run_check(self):
                 self.add_error("JSON Error")
 
         plugin_dir.reset()


### PR DESCRIPTION
The `subset` parameter added to `BaseHealthCheckBackend`'s `run_check` and `check_status` methods in 4da1fd9d broke compatibility with existing custom check backends, since they don't accept this parameter.

Moreover, this parameter appears to be entirely useless, since `check_status` is only called by `run_check`, and `run_check` is only called by `CheckMixin.run_check`, which never passed a value for `subset`.

Get rid of it and restore compatibility.

Fixes #413.