### PR TITLE
Fix S3Boto3Storage backend and test cases

### DIFF
--- a/health_check/contrib/s3boto3_storage/backends.py
+++ b/health_check/contrib/s3boto3_storage/backends.py
@@ -22,8 +22,7 @@ class S3Boto3StorageHealthCheck(StorageHealthCheck):
     storage_alias = "default"
 
     def check_delete(self, file_name):
-        try:
-            storage = self.get_storage()
-            storage.delete(file_name)
-        except Exception as e:
-            raise ServiceUnavailable("File was not deleted") from e
+        storage = self.get_storage()
+        if not storage.exists(file_name):
+            raise ServiceUnavailable("File does not exist")
+        storage.delete(file_name)

--- a/health_check/contrib/s3boto3_storage/backends.py
+++ b/health_check/contrib/s3boto3_storage/backends.py
@@ -1,6 +1,6 @@
 import logging
-from health_check.exceptions import ServiceUnavailable
 
+from health_check.exceptions import ServiceUnavailable
 from health_check.storage.backends import StorageHealthCheck
 
 

--- a/health_check/contrib/s3boto3_storage/backends.py
+++ b/health_check/contrib/s3boto3_storage/backends.py
@@ -1,4 +1,5 @@
 import logging
+from health_check.exceptions import ServiceUnavailable
 
 from health_check.storage.backends import StorageHealthCheck
 
@@ -18,7 +19,11 @@ class S3Boto3StorageHealthCheck(StorageHealthCheck):
 
     logger = logging.getLogger(__name__)
     storage = "storages.backends.s3boto3.S3Boto3Storage"
+    storage_alias = "default"
 
     def check_delete(self, file_name):
-        storage = self.get_storage()
-        storage.delete(file_name)
+        try:
+            storage = self.get_storage()
+            storage.delete(file_name)
+        except Exception as e:
+            raise ServiceUnavailable("File was not deleted") from e

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,6 +53,7 @@ test =
     pytest-django
     celery
     redis
+    django-storages
 docs =
     sphinx
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,6 +54,7 @@ test =
     celery
     redis
     django-storages
+    boto3
 docs =
     sphinx
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -75,5 +75,5 @@ class TestCommand:
             )
         stdout.seek(0)
         assert stdout.read() == (
-            f"Specify subset: '{NON_EXISTENCE_SUBSET_NAME}' does not exists.\n"
+            f"Subset: '{NON_EXISTENCE_SUBSET_NAME}' does not exist.\n"
         )

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,10 +1,13 @@
+from io import BytesIO
 import unittest
 from unittest import mock
 
 import django
 from django.core.files.storage import Storage
 from django.test import TestCase
-
+from health_check.contrib.s3boto3_storage.backends import S3Boto3StorageHealthCheck
+from django.test import override_settings
+from django.core.files.base import File
 from health_check.exceptions import ServiceUnavailable
 from health_check.storage.backends import (
     DefaultFileStorageHealthCheck,
@@ -43,6 +46,62 @@ class MockStorage(Storage):
     def save(self, name, content, max_length=None):
         if self.saves:
             self.MOCK_FILE_COUNT += 1
+
+
+# Mocking the S3Boto3Storage backend
+class MockS3Boto3Storage:
+    """
+    A mock S3Boto3Storage backend to simulate interactions with AWS S3.
+    """
+
+    def __init__(self, saves=True, deletes=True):
+        self.saves = saves
+        self.deletes = deletes
+        self.files = {}
+
+    def open(self, name, mode="rb"):
+        """
+        Simulates opening a file from the mocked S3 storage.
+        For simplicity, this doesn't differentiate between read and write modes.
+        """
+        if name in self.files:
+            # Assuming file content is stored as bytes
+            file_content = self.files[name]
+            if isinstance(file_content, bytes):
+                return File(BytesIO(file_content))
+            else:
+                raise ValueError("File content must be bytes.")
+        else:
+            raise FileNotFoundError(f"The file {name} does not exist.")
+
+    def save(self, name, content):
+        """
+        Overriding save to ensure content is stored as bytes in a way compatible with open method.
+        Assumes content is either a ContentFile, bytes, or a string that needs conversion.
+        """
+        if self.saves:
+            # Check if content is a ContentFile or similar and read bytes
+            if hasattr(content, "read"):
+                file_content = content.read()
+            elif isinstance(content, bytes):
+                file_content = content
+            elif isinstance(content, str):
+                file_content = content.encode()  # Convert string to bytes
+            else:
+                raise ValueError("Unsupported file content type.")
+
+            self.files[name] = file_content
+            return name
+        raise Exception("Failed to save file.")
+
+    def delete(self, name):
+        if self.deletes:
+            self.files.pop(name, None)
+        else:
+            raise Exception("Failed to delete file.")
+
+    def exists(self, name):
+        return name in self.files
 
 
 def get_file_name(*args, **kwargs):
@@ -156,3 +215,61 @@ class HealthCheckStorageTests(TestCase):
         default_storage_health = DefaultFileStorageHealthCheck()
         with self.assertRaises(ServiceUnavailable):
             default_storage_health.check_status()
+
+
+@mock.patch("storages.backends.s3boto3.S3Boto3Storage", new=MockS3Boto3Storage)
+@override_settings(
+    STORAGES={
+        "default": {"BACKEND": "storages.backends.s3boto3.S3Boto3Storage"},
+    }
+)
+class HealthCheckS3Boto3StorageTests(TestCase):
+    """
+    Tests health check behavior with a mocked S3Boto3Storage backend.
+    """
+
+    def test_check_delete_success(self):
+        """Test that check_delete correctly deletes a file when S3Boto3Storage is working."""
+        health_check = S3Boto3StorageHealthCheck()
+        mock_storage = health_check.get_storage()
+        file_name = "testfile.txt"
+        content = BytesIO(b"Test content")
+        mock_storage.save(file_name, content)
+
+        health_check.check_delete(file_name)
+        self.assertFalse(mock_storage.exists(file_name))
+
+    def test_check_delete_failure(self):
+        """Test that check_delete raises ServiceUnavailable when deletion fails."""
+        with mock.patch.object(
+            MockS3Boto3Storage,
+            "delete",
+            side_effect=Exception("Failed to delete file."),
+        ):
+            health_check = S3Boto3StorageHealthCheck()
+            with self.assertRaises(ServiceUnavailable):
+                health_check.check_delete("testfile.txt")
+
+    def test_check_status_working(self):
+        """Test check_status returns True when S3Boto3Storage can save and delete files."""
+        health_check = S3Boto3StorageHealthCheck()
+        self.assertTrue(health_check.check_status())
+
+    def test_check_status_failure_on_save(self):
+        """Test check_status raises ServiceUnavailable when file cannot be saved."""
+        with mock.patch.object(
+            MockS3Boto3Storage, "save", side_effect=Exception("Failed to save file.")
+        ):
+            health_check = S3Boto3StorageHealthCheck()
+            with self.assertRaises(ServiceUnavailable):
+                health_check.check_status()
+
+    def test_check_status_failure_on_delete(self):
+        """Test check_status raises ServiceUnavailable when file cannot be deleted."""
+        with mock.patch.object(
+            MockS3Boto3Storage, "delete", new_callable=mock.PropertyMock
+        ) as mock_deletes:
+            mock_deletes.return_value = False
+            health_check = S3Boto3StorageHealthCheck()
+            with self.assertRaises(ServiceUnavailable):
+                health_check.check_status()

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -267,9 +267,9 @@ class HealthCheckS3Boto3StorageTests(TestCase):
     def test_check_status_failure_on_delete(self):
         """Test check_status raises ServiceUnavailable when file cannot be deleted."""
         with mock.patch.object(
-            MockS3Boto3Storage, "delete", new_callable=mock.PropertyMock
-        ) as mock_deletes:
-            mock_deletes.return_value = False
+            MockS3Boto3Storage, "exists", new_callable=mock.PropertyMock
+        ) as mock_exists:
+            mock_exists.return_value = False
             health_check = S3Boto3StorageHealthCheck()
             with self.assertRaises(ServiceUnavailable):
                 health_check.check_status()

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,13 +1,13 @@
-from io import BytesIO
 import unittest
+from io import BytesIO
 from unittest import mock
 
 import django
-from django.core.files.storage import Storage
-from django.test import TestCase
-from health_check.contrib.s3boto3_storage.backends import S3Boto3StorageHealthCheck
-from django.test import override_settings
 from django.core.files.base import File
+from django.core.files.storage import Storage
+from django.test import TestCase, override_settings
+
+from health_check.contrib.s3boto3_storage.backends import S3Boto3StorageHealthCheck
 from health_check.exceptions import ServiceUnavailable
 from health_check.storage.backends import (
     DefaultFileStorageHealthCheck,


### PR DESCRIPTION
# Fix for `S3Boto3StorageHealthCheck` Failure in Version 3.18.0

## Problem Description

After upgrading from `django-health-check` version 3.17.0 to 3.18.0, several users have reported failures with the `S3Boto3StorageHealthCheck`. This issue appears to stem from `self.storage_alias` being `None` when it is used within the `S3Boto3StorageHealthCheck`, leading to an `AttributeError` when the code attempts to call the `save` method on a `NoneType` object. This behavior was not observed in version 3.17.0 and has been consistently reproducible in version 3.18.0.

## Additional Notes

This fix aims to restore the expected functionality of the S3Boto3StorageHealthCheck without altering the behavior of other storage health checks. Feedback and further testing are welcome to ensure comprehensive coverage and resolution of the issue.