### PR TITLE
Allow Configuration of Test Folder Path

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,14 @@ The backend will return a JSON response:
     }
 ```
 
+## Settings overrides
+
+You can provide `settings.HEALTH_CHECK_TEST_FOLDER` to alter the default storage behavior. It is helpful if your user doesn't have permissions to create a folder within the current dir.
+
+```python
+HEALTH_CHECK_TEST_FOLDER = '/tmp'
+```
+
 ## Writing a custom health check
 
 Writing a health check is quick and easy:

--- a/health_check/storage/backends.py
+++ b/health_check/storage/backends.py
@@ -1,3 +1,4 @@
+import os
 import uuid
 
 import django
@@ -43,7 +44,9 @@ class StorageHealthCheck(BaseHealthCheckBackend):
                 return self.storage
 
     def get_file_name(self):
-        return "health_check_storage_test/test-%s.txt" % uuid.uuid4()
+        path = settings.HEALTH_CHECK_TEST_FOLDER or 'health_check_storage_test'
+        filename = f'test-{uuid.uuid4()}.txt'
+        return os.path.join(path, filename)
 
     def get_file_content(self):
         return b"this is the healthtest file content"

--- a/health_check/storage/backends.py
+++ b/health_check/storage/backends.py
@@ -44,6 +44,15 @@ class StorageHealthCheck(BaseHealthCheckBackend):
                 return self.storage
 
     def get_file_name(self):
+        """
+        Generate a unique filename for a test file within the specified folder.
+
+        If the `HEALTH_CHECK_TEST_FOLDER` setting is defined, the generated filename will be within that folder.
+        Otherwise, it will be within a folder named 'health_check_storage_test' in the current directory.
+
+        Returns:
+            str: A string representing the path to the generated test file.
+        """
         path = settings.HEALTH_CHECK_TEST_FOLDER or 'health_check_storage_test'
         filename = f'test-{uuid.uuid4()}.txt'
         return os.path.join(path, filename)


### PR DESCRIPTION
Description:

This pull request addresses an issue where the library attempts to create a folder named health_check_storage_test within the current directory. However, in many setups, users may lack the necessary permissions to do so. To resolve this, the pull request introduces a feature that enables users to easily configure the folder/path through a setting.

Changes:

    Added support for configuring the folder/path using a setting.

    Users can now define the desired folder/path in their Django settings by adding the following line:

```python
HEALTH_CHECK_TEST_FOLDER = '/tmp'
```

This enhancement offers greater flexibility and ease of use for users, allowing them to specify a folder/path that suits their setup.