### PR TITLE
Add support for database specific health checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,20 @@ To use Health Check Subsets, Specify a subset name and associate it with the rel
     }
 ```
 
+To add checks on a specific database, it's possible to parameterize `DatabaseBackend` to use a specific database:
+```python
+    HEALTH_CHECK = {
+        # .....
+        "SUBSETS": {
+            "database-probe": [
+                "DatabaseBackend[default]",  # This is equivalent to "DatabaseBackend"
+                "DatabaseBackend[secondary]",
+            ],
+        },
+        # .....
+    }
+```
+
 To only execute specific subset of health check
 ```shell
 curl -X GET -H "Accept: application/json" http://www.example.com/ht/startup-probe/

--- a/health_check/db/apps.py
+++ b/health_check/db/apps.py
@@ -1,4 +1,5 @@
 from django.apps import AppConfig
+from django.conf import settings
 
 from health_check.plugins import plugin_dir
 
@@ -11,3 +12,6 @@ class HealthCheckConfig(AppConfig):
         from .backends import DatabaseBackend
 
         plugin_dir.register(DatabaseBackend)
+
+        for database_name in settings.DATABASES.keys():
+            plugin_dir.register(DatabaseBackend, database_name=database_name)

--- a/health_check/db/backends.py
+++ b/health_check/db/backends.py
@@ -1,4 +1,4 @@
-from django.db import DatabaseError, IntegrityError
+from django.db import DatabaseError, IntegrityError, transaction
 
 from health_check.backends import BaseHealthCheckBackend
 from health_check.exceptions import ServiceReturnedUnexpectedResult, ServiceUnavailable
@@ -7,13 +7,26 @@ from .models import TestModel
 
 
 class DatabaseBackend(BaseHealthCheckBackend):
+    database_name = ""
+
+    def __init__(self, database_name: str = "") -> None:
+        super().__init__()
+        self.database_name = database_name or None
+
     def check_status(self):
         try:
-            obj = TestModel.objects.create(title="test")
-            obj.title = "newtest"
-            obj.save()
-            obj.delete()
+            with transaction.atomic(using=self.database_name):
+                obj = TestModel.objects.create(title="test")
+                obj.title = "newtest"
+                obj.save()
+                obj.delete()
         except IntegrityError:
             raise ServiceReturnedUnexpectedResult("Integrity Error")
         except DatabaseError:
             raise ServiceUnavailable("Database error")
+
+    def identifier(self) -> str:
+        if not self.database_name:
+            return super().identifier()
+
+        return f"{self.__class__.__name__}[{self.database_name}]"

--- a/tests/test_autodiscover.py
+++ b/tests/test_autodiscover.py
@@ -22,7 +22,9 @@ class TestAutoDiscover:
         ]
 
         # The number of installed apps excluding celery should equal to all plugins except celery
-        assert len(non_celery_plugins) == len(health_check_plugins)
+        assert len(non_celery_plugins) == len(health_check_plugins) + len(
+            settings.DATABASES  # Each database creates specific health_check attached to it
+        )
 
     def test_discover_celery_queues(self):
         celery_plugins = [


### PR DESCRIPTION
Enables parameterised `DatabaseBackend` with specific database name like `DatabaseBackend[secondary]`.

Larger Django application can use specific databases to handle specific part of the application, some database might be required at application start-up while other are only used by non-vital part of the application.

This change allow a database per database health check configuration.

Part 1 of 3 for [Support multi Database Health Checks](https://github.com/revsys/django-health-check/issues/430)