### PR TITLE
Fix storage check exception handling

### DIFF
--- a/health_check/storage/backends.py
+++ b/health_check/storage/backends.py
@@ -75,6 +75,8 @@ class StorageHealthCheck(BaseHealthCheckBackend):
             file_name = self.check_save(file_name, file_content)
             self.check_delete(file_name)
             return True
+        except ServiceUnavailable as e:
+            raise e
         except Exception as e:
             raise ServiceUnavailable("Unknown exception") from e
 


### PR DESCRIPTION
All exceptions get converted to an unknown exception currently, but it would be better if that was only for unknown exceptions. Thanks for the great package :+1: