### PR TITLE
Add HEALTHCHECK_CELERY_PRIORITY

### DIFF
--- a/docs/contrib.rst
+++ b/docs/contrib.rst
@@ -43,6 +43,7 @@ If you are using Celery you may choose between two different Celery checks.
 
 `health_check.contrib.celery` sends a task to the queue and it expects that task
 to be executed in `HEALTHCHECK_CELERY_TIMEOUT` seconds which by default is three seconds.
+The task is sent with a priority of `HEALTHCHECK_CELERY_PRIORITY` (default priority by default).
 You may override that in your Django settings module. This check is suitable for use cases
 which require that tasks can be processed frequently all the time.
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -95,3 +95,7 @@ Using `django.settings` you may exert more fine-grained control over the behavio
      - Number
      - `3`
      - Specifies the maximum total time for a task to complete and return a result, including queue time.
+   * - `HEALTHCHECK_CELERY_PRIORITY`
+     - Number
+     - `None`
+     - Specifies the healthcheck task priority.

--- a/health_check/contrib/celery/backends.py
+++ b/health_check/contrib/celery/backends.py
@@ -12,10 +12,11 @@ class CeleryHealthCheck(BaseHealthCheckBackend):
         timeout = getattr(settings, "HEALTHCHECK_CELERY_TIMEOUT", 3)
         result_timeout = getattr(settings, "HEALTHCHECK_CELERY_RESULT_TIMEOUT", timeout)
         queue_timeout = getattr(settings, "HEALTHCHECK_CELERY_QUEUE_TIMEOUT", timeout)
+        priority = getattr(settings, "HEALTHCHECK_CELERY_PRIORITY", None)
 
         try:
             result = add.apply_async(
-                args=[4, 4], expires=queue_timeout, queue=self.queue
+                args=[4, 4], expires=queue_timeout, queue=self.queue, priority=priority
             )
             result.get(timeout=result_timeout)
             if result.result != 8:


### PR DESCRIPTION
Healthcheck might be flaky when there are many tasks in queue with higher-than-default priority.

This PR allows setting HEALTHCHECK_CELERY_PRIORITY in order to prioritize the healthcheck.