### PR TITLE
Feature/allow redis connection kwargs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,4 @@ ENV/
 
 # mac
 .DS_Store
+.aider*

--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ It can be customized by setting `HEALTHCHECK_CACHE_KEY` to another value:
     HEALTHCHECK_CACHE_KEY = "custom_healthcheck_key"
 ```
 
+Additional connection options may be specified by defining a variable ``HEALTHCHECK_REDIS_URL_OPTIONS`` on the settings module.
+
 ## Setting up monitoring
 
 You can use tools like Pingdom, StatusCake or other uptime robots to monitor service status.

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -59,6 +59,10 @@ The cache backend uses the following setting:
      - String
      - `djangohealthcheck_test`
      - Specifies the name of the key to write to and read from to validate that the cache is working.
+   * - `HEALTHCHECK_REDIS_URL_OPTIONS`
+     - Dict
+     - {}
+     - Additional arguments which will be passed as keyword arguments to the Redis connection class initialiser.
 
 `psutil`
 --------

--- a/health_check/contrib/redis/backends.py
+++ b/health_check/contrib/redis/backends.py
@@ -13,6 +13,7 @@ class RedisHealthCheck(BaseHealthCheckBackend):
     """Health check for Redis."""
 
     redis_url = getattr(settings, "REDIS_URL", "redis://localhost/1")
+    redis_url_options = getattr(settings, "HEALTHCHECK_REDIS_URL_OPTIONS", {})
 
     def check_status(self):
         """Check Redis service by pinging the redis instance with a redis connection."""
@@ -21,7 +22,7 @@ class RedisHealthCheck(BaseHealthCheckBackend):
         logger.debug("Attempting to connect to redis...")
         try:
             # conn is used as a context to release opened resources later
-            with from_url(self.redis_url) as conn:
+            with from_url(self.redis_url, **self.redis_url_options) as conn:
                 conn.ping()  # exceptions may be raised upon ping
         except ConnectionRefusedError as e:
             self.add_error(

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -28,7 +28,7 @@ class TestRedisHealthCheck:
         assert len(redis_healthchecker.errors), 1
 
         # mock assertions
-        mocked_connection.assert_called_once_with("redis://localhost/1")
+        mocked_connection.assert_called_once_with("redis://localhost/1", **{})
 
     @mock.patch("health_check.contrib.redis.backends.getattr")
     @mock.patch("health_check.contrib.redis.backends.from_url")
@@ -50,7 +50,7 @@ class TestRedisHealthCheck:
         assert len(redis_healthchecker.errors), 1
 
         # mock assertions
-        mocked_connection.assert_called_once_with("redis://localhost/1")
+        mocked_connection.assert_called_once_with("redis://localhost/1", **{})
 
     @mock.patch("health_check.contrib.redis.backends.getattr")
     @mock.patch("health_check.contrib.redis.backends.from_url")
@@ -72,7 +72,7 @@ class TestRedisHealthCheck:
         assert len(redis_healthchecker.errors), 1
 
         # mock assertions
-        mocked_connection.assert_called_once_with("redis://localhost/1")
+        mocked_connection.assert_called_once_with("redis://localhost/1", **{})
 
     @mock.patch("health_check.contrib.redis.backends.getattr")
     @mock.patch("health_check.contrib.redis.backends.from_url")
@@ -92,4 +92,4 @@ class TestRedisHealthCheck:
         assert len(redis_healthchecker.errors), 0
 
         # mock assertions
-        mocked_connection.assert_called_once_with("redis://localhost/1")
+        mocked_connection.assert_called_once_with("redis://localhost/1", **{})


### PR DESCRIPTION
Allows customizing how the connection to redis gets made by explicitly passing a URL options dict to the `from_url` function.

This supports use cases defined in the original PR: https://github.com/revsys/django-health-check/pull/304