### PR TITLE
Drop support Python/Django versions which reach their EOL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,24 +62,12 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"
         django-version:
-          - "2.2"
-          - "3.2"
-          - "4.1"
           - "4.2"
-          - "5.0"
-        exclude:
-          - python-version: "3.12"
-            django-version: "2.2"
-          - python-version: "3.8"
-            django-version: "5.0"
-          - python-version: "3.9"
-            django-version: "5.0"
     steps:
       - uses: actions/checkout@v3
       - name: Setup Python version ${{ matrix.python-version }}

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,20 +11,13 @@ license_file = LICENSE
 classifier =
   Development Status :: 5 - Production/Stable
   Framework :: Django
-  Framework :: Django :: 2.2
-  Framework :: Django :: 3.1
-  Framework :: Django :: 3.2
-  Framework :: Django :: 4.0
-  Framework :: Django :: 4.1
   Framework :: Django :: 4.2
-  Framework :: Django :: 5.0
   Intended Audience :: Developers
   License :: OSI Approved :: MIT License
   Operating System :: OS Independent
   Programming Language :: Python
   Programming Language :: Python :: 3
   Programming Language :: Python :: 3 :: Only
-  Programming Language :: Python :: 3.8
   Programming Language :: Python :: 3.9
   Programming Language :: Python :: 3.10
   Programming Language :: Python :: 3.11
@@ -38,7 +31,7 @@ keywords =
   postgresql
 
 [options]
-python_requires = >=3.8
+python_requires = >=3.9
 include_package_data = True
 packages = health_check
 install_requires =


### PR DESCRIPTION
Drop Django

* 2.2
* 3.2
* 4.1
* 5.0

Drop Python

* 3.8