### PR TITLE
Repair VERSION variable

### DIFF
--- a/health_check/__init__.py
+++ b/health_check/__init__.py
@@ -3,4 +3,4 @@
 from . import _version  # noqa
 
 __version__ = _version.__version__
-VERSION = _version.VERSION_TUPLE
+VERSION = _version.__version_tuple__


### PR DESCRIPTION
`VERSION_TUPLE` only resolves to an uninitialized object or tuple (depending on whether type checking is enabled). The real version tuple is contained in `__version_tuple__`.

Fixes: 96dd3bc4aa6e ("Adapt PEP 612 (pyproject.toml) package metadata")