### PR TITLE
minor bug: convert cache timeout to integer instead of float

### DIFF
--- a/health_check/checks.py
+++ b/health_check/checks.py
@@ -75,7 +75,7 @@ class Cache(HealthCheck):
             await cache.aset(
                 cache_key,
                 cache_value,
-                timeout=self.timeout.total_seconds(),
+                timeout=int(self.timeout.total_seconds()),
             )
             if not await cache.aget(cache_key) == cache_value:
                 raise ServiceUnavailable(f"Cache key {cache_key} does not match")

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -56,7 +56,7 @@ class TestCache:
             cache_key = mock_cache.aset.await_args.args[0]
             assert cache_key.startswith("djangohealthcheck_test:")
             assert cache_key != "djangohealthcheck_test"
-            assert mock_cache.aset.await_args.kwargs["timeout"] == 5.0
+            assert mock_cache.aset.await_args.kwargs["timeout"] == 5
 
     @pytest.mark.asyncio
     async def test_run_check__cache_timeout_is_configurable(self):
@@ -74,7 +74,7 @@ class TestCache:
             check = Cache(timeout=datetime.timedelta(seconds=2))
             result = await check.get_result()
             assert result.error is None
-            assert mock_cache.aset.await_args.kwargs["timeout"] == 2.0
+            assert mock_cache.aset.await_args.kwargs["timeout"] == 2
 
     @pytest.mark.asyncio
     async def test_run_check__cache_supports_key_prefix_argument(self):


### PR DESCRIPTION
`self.timeout.total_seconds()` returns a float, and [Django's cache framework expects it to be an integer instead of a float.](https://docs.djangoproject.com/en/6.0/ref/settings/#timeout)

I have converted the float to an integer, and altered the tests to reflect that.