### PR TITLE
Fix #742 -- Remove blank lines in OpenMetrics output

### DIFF
--- a/health_check/views.py
+++ b/health_check/views.py
@@ -242,7 +242,6 @@ class HealthCheckView(TemplateView):
 
         # Add response time metrics
         lines += [
-            "",
             "# HELP django_health_check_response_time_seconds Health check response time in seconds",
             "# TYPE django_health_check_response_time_seconds gauge",
         ]
@@ -254,7 +253,6 @@ class HealthCheckView(TemplateView):
 
         # Add overall health status
         lines += [
-            "",
             "# HELP django_health_check_overall_status Overall health check status (1 = all healthy, 0 = at least one unhealthy)",
             "# TYPE django_health_check_overall_status gauge",
             f"django_health_check_overall_status {not has_errors:d}",

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -810,6 +810,22 @@ class TestHealthCheckView:
         assert "django_health_check_response_time_seconds" in content
         assert "django_health_check_overall_status" in content
         assert "# EOF" in content
+
+    @pytest.mark.asyncio
+    async def test_get__openmetrics_format__no_empty_lines(self, health_check_view):
+        """
+        Ensure OpenMetrics output does not contain empty lines.
+
+        Regression, see also:
+        https://github.com/codingjoe/django-health-check/issues/742
+        """
+
+        class SuccessBackend(HealthCheck):
+            async def run(self):
+                pass
+
+        response = await health_check_view([SuccessBackend], format_param="openmetrics")
+        content = response.content.decode("utf-8")
         assert not any(line == "" for line in content.splitlines())
 
     @pytest.mark.asyncio

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -810,6 +810,7 @@ class TestHealthCheckView:
         assert "django_health_check_response_time_seconds" in content
         assert "django_health_check_overall_status" in content
         assert "# EOF" in content
+        assert not any(line == "" for line in content.splitlines())
 
     @pytest.mark.asyncio
     async def test_get__openmetrics_accept_header_openmetrics(self, health_check_view):


### PR DESCRIPTION
## Summary

Remove blank separator lines from the OpenMetrics response emitted by `render_to_response_openmetrics()`.

Fixes #742.

## Why

Prometheus 3.x negotiates the endpoint as `application/openmetrics-text` and rejects the current output when it encounters an empty line between metric families:

```text
expected a valid start token, got "\n" ("INVALID")
```

OpenMetrics output still remains newline-delimited and ends with `# EOF`; it just avoids emitting empty metric lines.

## Validation

- `uv run pytest tests/test_views.py -k openmetrics`
- `uv run --with ruff ruff check health_check/views.py tests/test_views.py`
