### PR TITLE
Add alias label for Redis health checks

### DIFF
--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -192,7 +192,10 @@ application_checks = [
     # Message brokers & caches
     (
         "health_check.contrib.redis.Redis",
-        {"client_factory": lambda: RedisClient.from_url("redis://localhost:6379")},
+        {
+            "alias": "default",
+            "client_factory": lambda: RedisClient.from_url("redis://localhost:6379"),
+        },
     ),
     (
         "health_check.contrib.rabbitmq.RabbitMQ",
@@ -328,7 +331,10 @@ application_checks = [
     "health_check.Storage",
     (
         "health_check.contrib.redis.Redis",
-        {"client_factory": lambda: RedisClient.from_url("redis://localhost:6379")},
+        {
+            "alias": "default",
+            "client_factory": lambda: RedisClient.from_url("redis://localhost:6379"),
+        },
     ),
     (
         "health_check.contrib.rabbitmq.RabbitMQ",

--- a/docs/install.md
+++ b/docs/install.md
@@ -52,6 +52,7 @@ urlpatterns = [
                 (
                     "health_check.contrib.redis.Redis",
                     {
+                        "alias": "default",
                         "client_factory": lambda: RedisClient.from_url(
                             "redis://localhost:6379"
                         )

--- a/docs/install.md
+++ b/docs/install.md
@@ -55,7 +55,7 @@ urlpatterns = [
                         "alias": "default",
                         "client_factory": lambda: RedisClient.from_url(
                             "redis://localhost:6379"
-                        )
+                        ),
                     },
                 ),
                 # AWS service status check

--- a/health_check/contrib/redis.py
+++ b/health_check/contrib/redis.py
@@ -24,6 +24,7 @@ class Redis(HealthCheck):
     including standard Redis, Sentinel, and Cluster clients.
 
     Args:
+        alias: Optional label used to identify this Redis check in reports and metrics.
         client_factory: A callable that returns an instance of a Redis client.
         client: Deprecated, use `client_factory` instead.
 
@@ -46,6 +47,7 @@ class Redis(HealthCheck):
 
     """
 
+    alias: str | None = None
     client: RedisClient | RedisCluster | None = dataclasses.field(
         repr=False, default=None
     )

--- a/tests/contrib/test_redis.py
+++ b/tests/contrib/test_redis.py
@@ -149,6 +149,14 @@ class TestRedis:
         ):
             RedisHealthCheck()
 
+    def test_redis__labels_include_alias(self):
+        """Include optional alias in labels without exposing Redis clients."""
+        mock_client = mock.AsyncMock()
+
+        check = RedisHealthCheck(alias="channels", client_factory=lambda: mock_client)
+
+        assert check.labels == {"check": "Redis", "alias": "channels"}
+
     def test_redis__repr_standard_client(self):
         """Verify repr includes host and db for a standard Redis client."""
         # https://github.com/codingjoe/django-health-check/issues/659


### PR DESCRIPTION
## Summary

- add an optional `alias` field to the Redis health check
- expose the alias through `HealthCheck.labels` so OpenMetrics can distinguish multiple Redis checks
- document `alias` in the Redis check docstring and Redis configuration examples

Closes #743

## Tests

- `uv run --extra redis --group test pytest tests/contrib/test_redis.py -q`
- `uv run --with ruff ruff check health_check/contrib/redis.py tests/contrib/test_redis.py`