### PR TITLE
Document that the health_check URL pattern requires a name

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -64,9 +64,15 @@ urlpatterns = [
                 ),
             ],
         ),
+        name="health_check",
     ),
 ]
 ```
+
+> [!NOTE]
+> The `name` argument is required so that the `health_check` management command can
+> resolve this endpoint URL via `reverse()`. When using the command, pass this name as
+> the `endpoint` argument, e.g. `django-admin health_check health_check`.
 
 ## Security
 
@@ -87,6 +93,10 @@ You can protect the health check endpoint by adding a secure token to your URL.
 
    urlpatterns = [
        # …
-       path("health/super_secret_token/", HealthCheckView.as_view()),
+       path(
+           "health/super_secret_token/",
+           HealthCheckView.as_view(),
+           name="health_check",
+       ),
    ]
    ```

--- a/docs/migrate-to-v4.md
+++ b/docs/migrate-to-v4.md
@@ -50,6 +50,7 @@
                "health_check.contrib.redis.Redis",
            ]
        ),
+       name="health_check",
    )
    ```
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -129,18 +129,26 @@ You can run the Django command `health_check` to perform your health
 checks via the command line, or periodically with a cron, as follows:
 
 ```shell
-django-admin health_check --help
+django-admin health_check health_check
 ```
 
-This should yield the following output:
+The `endpoint` argument is the `name` of the health check URL pattern defined in your
+`urls.py` (see the [installation guide](install.md)); the command resolves it via
+`reverse()`. The example above runs the checks over HTTP against the running server:
 
 ```
 Database                 ... OK
 CustomHealthCheck        ... Unavailable: Something went wrong!
 ```
 
-Similar to the http version, a critical error will cause the command to
-quit with the exit code `1`.
+Pass `--no-http` to run the checks directly without an HTTP server, which is useful for
+container health checks where no web server needs to be running:
+
+```shell
+django-admin health_check health_check --no-http
+```
+
+A critical error will cause the command to quit with the exit code `1`.
 
 ## Performance tweaks
 


### PR DESCRIPTION
## Why

The `django-admin health_check <endpoint>` command resolves its endpoint via Django's `reverse(endpoint)`, so the `<endpoint>` argument is a **URL pattern name** - not a path. The setup docs never added a `name=` to the `path()` in `urls.py`, so anyone following the docs who then runs the CLI hits:

```
Could not resolve endpoint 'ht': Reverse for 'ht' not found.
```

This is a documentation-only fix; the command's reverse lookup behavior is unchanged.

## What changed

- **docs/install.md**: Added `name="health_check"` to the main URL example and a note explaining that the CLI's `endpoint` argument is this URL pattern name (e.g. `django-admin health_check health_check`). Also added `name=` to the Security section example for consistency.
- **docs/usage.md**: Replaced the placeholder `--help` example with a real invocation, documented that `endpoint` is the URL pattern name from `urls.py`, and added a `--no-http` example for container health checks.
- **docs/migrate-to-v4.md**: Added `name=` to the v3 to v4 migration "After" example so users who migrate from `include("health_check.urls")` keep CLI compatibility.

## Notes

- Chose `name="health_check"` for the primary example, consistent with the existing cookbook convention (`health_check-node`, `health_check-application`, ...).
- No code changes.

Fixes: #760