### PR TITLE
Fix CI by managing integration services with testcontainers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,44 +57,6 @@ jobs:
           flags: python-${{ matrix.python-version }}-django-${{ matrix.django-version }}
   pytest-contrib:
     name: pytest
-    services:
-      redis:
-        image: redis
-        ports:
-          - 6379:6379
-        options: --entrypoint redis-server
-      redis-sentinel:
-        image: bitnami/redis-sentinel:latest
-        ports:
-          - 26379:26379
-        env:
-          REDIS_MASTER_HOST: redis
-          REDIS_MASTER_SET: mymaster
-          REDIS_SENTINEL_QUORUM: 1
-      rabbitmq:
-        image: rabbitmq:3-management
-        ports:
-          - 5672:5672
-          - 15672:15672
-      kafka:
-        image: apache/kafka
-        ports:
-          - 9092:9092
-        env:
-          KAFKA_NODE_ID: 0
-          KAFKA_PROCESS_ROLES: controller,broker
-          KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093
-          KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
-          KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT
-          KAFKA_CONTROLLER_QUORUM_VOTERS: 0@localhost:9093
-          KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
-    env:
-      REDIS_URL: redis://localhost:6379/0
-      REDIS_SENTINEL_URL: redis-sentinel://localhost:26379/mymaster
-      REDIS_SENTINEL_NODES: localhost:26379
-      REDIS_SENTINEL_SERVICE_NAME: mymaster
-      RABBITMQ_URL: amqp://guest:guest@localhost:5672//
-      KAFKA_BOOTSTRAP_SERVERS: localhost:9092
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ test = [
   "pytest-django",
   "django-storages",
   "boto3",
+  "testcontainers",
 ]
 docs = [
   "mkdocs",

--- a/tests/contrib/conftest.py
+++ b/tests/contrib/conftest.py
@@ -1,0 +1,81 @@
+"""Pytest fixtures that run integration test dependencies in containers."""
+
+import pytest
+
+
+def _require_docker() -> None:
+    """Skip the test when a Docker daemon is not reachable."""
+    from docker import from_env
+    from docker.errors import DockerException
+
+    try:
+        from_env().ping()
+    except DockerException as exc:
+        pytest.skip(f"Docker daemon is not available: {exc}")
+
+
+@pytest.fixture(scope="module")
+def redis_url():
+    """Start a Redis container and return its URL."""
+    from testcontainers.community.redis import RedisContainer
+
+    _require_docker()
+    with RedisContainer("redis:7") as redis:
+        yield f"redis://localhost:{redis.get_exposed_port(6379)}/0"
+
+
+@pytest.fixture(scope="module")
+def redis_sentinel():
+    """Start a Redis master and a Sentinel, return their nodes and service name."""
+    from testcontainers.community.redis import RedisContainer
+    from testcontainers.core.container import DockerContainer
+
+    _require_docker()
+    with RedisContainer("redis:7") as master:
+        master_port = master.get_exposed_port(6379)
+        conf = (
+            "port 26379\n"
+            f"sentinel monitor mymaster 127.0.0.1 {master_port} 1\n"
+            "sentinel down-after-milliseconds mymaster 5000\n"
+            "sentinel failover-timeout mymaster 60000\n"
+            "sentinel parallel-syncs mymaster 1\n"
+        )
+        sentinel = (
+            DockerContainer("redis:7")
+            .with_command(
+                "sh -c 'chmod 666 /tmp/sentinel.conf "
+                "&& redis-server /tmp/sentinel.conf --sentinel'"
+            )
+            .with_copy_into_container(
+                conf.encode(),
+                "/tmp/sentinel.conf",  # noqa: S108 - path is inside the container
+            )
+            .with_exposed_ports(26379)
+        )
+        with sentinel:
+            nodes = [("localhost", sentinel.get_exposed_port(26379))]
+            yield nodes, "mymaster"
+
+
+@pytest.fixture(scope="module")
+def kafka_bootstrap_servers():
+    """Fixture that returns a running Kafka bootstrap server address."""
+    from testcontainers.community.kafka import KafkaContainer
+
+    _require_docker()
+    with KafkaContainer() as kafka:
+        yield kafka.get_bootstrap_server()
+
+
+@pytest.fixture(scope="module")
+def rabbitmq_url():
+    """Return a connection URL for a running RabbitMQ broker."""
+    from testcontainers.core.container import DockerContainer
+    from testcontainers.core.wait_strategies import LogMessageWaitStrategy
+
+    _require_docker()
+    container = DockerContainer("rabbitmq:3-management")
+    container.with_exposed_ports(5672)
+    container.waiting_for(LogMessageWaitStrategy("Server startup complete"))
+    with container:
+        yield f"amqp://guest:guest@localhost:{container.get_exposed_port(5672)}//"

--- a/tests/contrib/test_kafka.py
+++ b/tests/contrib/test_kafka.py
@@ -1,7 +1,6 @@
 """Tests for Kafka health check."""
 
 import datetime
-import os
 from unittest import mock
 
 import pytest
@@ -96,13 +95,9 @@ class TestKafka:
 
     @pytest.mark.integration
     @pytest.mark.asyncio
-    async def test_check_status__real_kafka(self):
-        """Connect to real Kafka server when KAFKA_BOOTSTRAP_SERVERS is configured."""
-        kafka_servers = os.getenv("KAFKA_BOOTSTRAP_SERVERS")
-        if not kafka_servers:
-            pytest.skip("KAFKA_BOOTSTRAP_SERVERS not set; skipping integration test")
-
-        check = KafkaHealthCheck(bootstrap_servers=kafka_servers.split(","))
+    async def test_check_status__real_kafka(self, kafka_bootstrap_servers):
+        """Connect to a real Kafka server and report missing topics."""
+        check = KafkaHealthCheck(bootstrap_servers=[kafka_bootstrap_servers])
         result = await check.get_result()
         assert result.error
         assert isinstance(result.error, ServiceUnavailable)

--- a/tests/contrib/test_rabbitmq.py
+++ b/tests/contrib/test_rabbitmq.py
@@ -1,6 +1,5 @@
 """Tests for RabbitMQ health check."""
 
-import os
 from unittest import mock
 
 import pytest
@@ -87,12 +86,8 @@ class TestRabbitMQ:
 
     @pytest.mark.integration
     @pytest.mark.asyncio
-    async def test_check_status__real_rabbitmq(self):
-        """Connect to real RabbitMQ server when BROKER_URL is configured."""
-        broker_url = os.getenv("BROKER_URL") or os.getenv("RABBITMQ_URL")
-        if not broker_url:
-            pytest.skip("BROKER_URL/RABBITMQ_URL not set; skipping integration test")
-
-        check = RabbitMQHealthCheck(amqp_url=broker_url)
+    async def test_check_status__real_rabbitmq(self, rabbitmq_url):
+        """Connect to a real RabbitMQ server."""
+        check = RabbitMQHealthCheck(amqp_url=rabbitmq_url)
         result = await check.get_result()
         assert result.error is None

--- a/tests/contrib/test_redis.py
+++ b/tests/contrib/test_redis.py
@@ -1,6 +1,5 @@
 """Tests for Redis health check."""
 
-import os
 from unittest import mock
 
 import pytest
@@ -338,13 +337,10 @@ class TestRedis:
         )
         assert check.labels == {"check": "Redis"}
 
+    @pytest.mark.integration
     @pytest.mark.asyncio
-    async def test_redis__real_connection(self):
-        """Ping real Redis server when REDIS_URL is configured."""
-        redis_url = os.getenv("REDIS_URL")
-        if not redis_url:
-            pytest.skip("REDIS_URL not set; skipping integration test")
-
+    async def test_redis__real_connection(self, redis_url):
+        """Ping a real Redis server."""
         from redis.asyncio import Redis as RedisClient
 
         check = RedisHealthCheck(client_factory=lambda: RedisClient.from_url(redis_url))
@@ -353,27 +349,14 @@ class TestRedis:
 
     @pytest.mark.integration
     @pytest.mark.asyncio
-    async def test_redis__real_sentinel(self):
-        """Ping real Redis Sentinel when configured."""
-        sentinel_url = os.getenv("REDIS_SENTINEL_URL")
-        if not sentinel_url:
-            pytest.skip("REDIS_SENTINEL_URL not set; skipping integration test")
-
+    async def test_redis__real_sentinel(self, redis_sentinel):
+        """Ping a real Redis Sentinel."""
         from redis.asyncio import Sentinel
 
-        # Parse sentinel configuration from environment
-        sentinel_nodes = os.getenv("REDIS_SENTINEL_NODES", "localhost:26379")
-        service_name = os.getenv("REDIS_SENTINEL_SERVICE_NAME", "mymaster")
+        sentinel_nodes, service_name = redis_sentinel
 
-        # Parse sentinel nodes from comma-separated list
-        sentinels = []
-        for node in sentinel_nodes.split(","):
-            host, port = node.strip().split(":")
-            sentinels.append((host, int(port)))
-
-        # Create factory that returns Sentinel master client
         def factory():
-            sentinel = Sentinel(sentinels)
+            sentinel = Sentinel(sentinel_nodes)
             return sentinel.master_for(service_name)
 
         check = RedisHealthCheck(client_factory=factory)


### PR DESCRIPTION
The `pytest-contrib` CI job managed its integration dependencies (Redis, Redis Sentinel, RabbitMQ, Kafka) through GitHub Actions `services:` containers. The Bitnami `redis-sentinel` image began refusing to start without `ALLOW_EMPTY_PASSWORD=yes`, which broke the `redis` matrix jobs with `Unable to connect to Redis: Connection Error`.

## Approach

Moved integration dependency management into pytest fixtures backed by the `testcontainers` package, so the CI job is self-contained and reproducible instead of depending on fragile service containers.

- Added `testcontainers` to the `test` dependency group.
- Added `tests/contrib/conftest.py` with fixtures that start containers for each integration test:
  - `redis_url` starts a Redis 7 container.
  - `redis_sentinel` starts a Redis master and a Sentinel that advertises the master at a host-reachable address.
  - `kafka_bootstrap_servers` starts a Kafka broker.
  - `rabbitmq_url` starts RabbitMQ via a generic container, avoiding a `pika` dependency on every CI job.
  - `_require_docker()` skips cleanly when no Docker daemon is reachable.
- Refactored the integration tests in `test_redis.py`, `test_kafka.py`, and `test_rabbitmq.py` to consume these fixtures instead of reading environment variables.
- Removed the `services:` and `env:` blocks from `ci.yml`.

## Notes for review

- The Redis Sentinel fixture advertises the master at `127.0.0.1:<host_port>` so the host-side client can reach the master; the sentinel does not need to reach the master itself for the health check to pass.
- The RabbitMQ fixture deliberately uses a plain `DockerContainer` with a log-based readiness check rather than the `testcontainers` RabbitMQ module, so the `rabbitmq` extra does not need to pull in `pika`.
- Integration tests skip gracefully when Docker is unavailable, preserving local development without a daemon.

Verified locally against real containers: all Redis, Kafka, and RabbitMQ integration tests pass, and the base (no-extra) suite is unaffected.